### PR TITLE
Update modal docs and create demos for modal full and snap

### DIFF
--- a/docs/build/css/sassquatch.css
+++ b/docs/build/css/sassquatch.css
@@ -490,7 +490,7 @@ title: Modal Dialog Mixin
 parent: modalUtils
 ---
 
-Use this mixin to get the behavior of a [link Snap Modal View][snapModalView],
+Use this mixin to get the behavior of a [Snap Modal View][snapModalView],
 a view that snaps to full page on small screens and a dialog on larger formats.
 
 ```
@@ -505,7 +505,7 @@ parent: modalUtils
 ---
 
 Use this mixin to get behavior of a full page modal.
-See [link the Full Modal View documentation][fullModalView]
+See [the Full Modal View documentation][fullModalView]
 
 ```
 	@include modal-full;
@@ -2659,18 +2659,29 @@ title: Modals
 name: modals
 category: Views
 ---
+
+## view--modal variants
+
+Class                      | Description
+-------------------------- | ---------------------------
+`.view-modal--full`        | Makes a modal that is full screen on all screen sizes
+`.view-modal--snap`        | Creates a modal that is full screen on small sizes, overlay/dialog on larger screens
+
+
 */
 /*doc
 ---
-title: Full Modal View
+title: Full Modal View 
 name: fullModalView
 parent: modals
 ---
 
 Modal that is presented full screen on all sizes
 
-```
-<div class="view view--modal-full">
+```html_example
+<a class="link" href="pages/modal-full.html">Demo</a> 
+
+<div class="view view--modal-full display--none">
 	<header class="view-head">
 		<div class="row inverted"> 
 			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
@@ -2690,47 +2701,7 @@ Modal that is presented full screen on all sizes
 	</div>
 </div>
 ```
-*/
-/* TODO make demo page with code
-<div id="fullModal" class="view view--modal-full">
-	<header id="modal_header" class="view-head">
-		<div class="row inverted"> 
-			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
-			<img src="style/img/logo.svg" width="35" height="24"></a>
-			<div class="row-item row-item--alignMiddle viewHead-heading">
-				<h1 class="wrap--singleLine--truncate">Text post</h1> 
-			</div>
-			<div class="viewHead-actions row row-item row-item--shrink row-item--alignMiddle"> </div>
-		</div>
-	</header>
-	<div id="modal_body" class="view-body">
-		<div class="stripe">
-			<div class="bounds">
-				<div class="chunk">
-					<div class="row">
-						<div class="row-item--shrink">
-							<div class="avatar avatar--person avatar--small" style="background-image: url(http://api.randomuser.me/0.3/portraits/women/7.jpg);"></div>
-						</div> 
-						<div class="row-item">Sally Smeetup</div>
-					</div>
-				</div>
-				<div class="chunk">
-					<textarea id="post-textarea"></textarea>
-				</div>
-				<div class="chunk">
-					<div class="row">
-						<div class="row-item--shrink row-item--alignMiddle">
-							<a href="#" class="button button--primary">Post</a>
-						</div>
-						<div class="row-item row-item--alignMiddle">
-							<p class="text--caption">Visible to: members and non-members</p>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-</div>
+
 */
 .view--modal-full {
   -webkit-transform: translate3d(0, 0, 0);
@@ -2753,7 +2724,7 @@ Modal that is presented full screen on all sizes
 
 /*doc
 ---
-title: Snap Modal View (Dialog)
+title: Snap Modal View (Dialog) 
 name: snapModalView
 parent: modals
 ---
@@ -2761,8 +2732,11 @@ parent: modals
 Modal that snaps to the whole viewport and is full screen on small screens,
 lays out as a dialog on background content on larger screens.
 
-```
-<div class="view view--modal-snap">
+
+```html_example
+<a class="link" href="pages/modal-snap.html">Demo</a> 
+
+<div class="view view--modal-snap display--none">
 	<header class="view-head">
 		<div class="row inverted"> 
 			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
@@ -2778,53 +2752,12 @@ lays out as a dialog on background content on larger screens.
 			<div class="bounds">
 			... body content here ...
 			
-			<button>Save</button>
+				<button>Save</button>
 			</div>
 		</div>
 	</div>
 </div>
 ```
-*/
-/* TODO demo page
-<div id="modal" class="view view--modal-snap">
-	<header id="modal_header" class="view-head">
-		<div class="row inverted"> 
-			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
-			<img src="style/img/logo.svg" width="35" height="24"></a>
-			<div class="row-item row-item--alignMiddle viewHead-heading">
-				<h1 class="wrap--singleLine--truncate">Text post</h1> 
-			</div>
-			<div class="viewHead-actions row row-item row-item--shrink row-item--alignMiddle"> </div>
-		</div>
-	</header>
-	<div id="modal_body" class="view-body">
-		<div class="stripe">
-			<div class="bounds">
-				<div class="chunk">
-					<div class="row">
-						<div class="row-item--shrink">
-							<div class="avatar avatar--person avatar--small" style="background-image: url(http://api.randomuser.me/0.3/portraits/women/7.jpg);"></div>
-						</div> 
-						<div class="row-item">Sally Smeetup</div>
-					</div>
-				</div>
-				<div class="chunk">
-					<textarea id="post-textarea"></textarea>
-				</div>
-				<div class="chunk">
-					<div class="row">
-						<div class="row-item--shrink row-item--alignMiddle">
-							<a href="#" class="button button--primary">Post</a>
-						</div>
-						<div class="row-item row-item--alignMiddle">
-							<p class="text--caption">Visible to: members and non-members</p>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-</div>
 */
 .view--modal-snap {
   -webkit-transform: translate3d(0, 0, 0);

--- a/docs/build/css/sassquatch.css
+++ b/docs/build/css/sassquatch.css
@@ -476,6 +476,44 @@ Clears floated children.
 
 /*doc
 ---
+title: Modal mixins
+name: modalUtils
+category: Sass Utils | Mixins & Placeholders
+---
+
+Description here
+
+*/
+/*doc
+---
+title: Modal Dialog Mixin
+parent: modalUtils
+---
+
+Use this mixin to get the behavior of a [link Snap Modal View][snapModalView],
+a view that snaps to full page on small screens and a dialog on larger formats.
+
+```
+	@include modal-dialog;
+
+```
+*/
+/*doc
+---
+title: Modal Full Mixin
+parent: modalUtils
+---
+
+Use this mixin to get behavior of a full page modal.
+See [link the Full Modal View documentation][fullModalView]
+
+```
+	@include modal-full;
+
+```
+*/
+/*doc
+---
 title: Shadow utilities
 name: shadow
 category: Sass Utils | Mixins & Placeholders
@@ -2615,6 +2653,85 @@ content container for the view.
   height: 100vh;
   overflow: auto; }
 
+/*doc
+---
+title: Modals
+name: modals
+category: Views
+---
+*/
+/*doc
+---
+title: Full Modal View
+name: fullModalView
+parent: modals
+---
+
+Modal that is presented full screen on all sizes
+
+```
+<div class="view view--modal-full">
+	<header class="view-head">
+		<div class="row inverted"> 
+			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
+				<img src="style/img/logo.svg" width="35" height="24"></a>
+			</a>
+			<div class="row-item row-item--alignMiddle viewHead-heading">
+				<h1 class="wrap--singleLine--truncate">This is a header</h1> 
+			</div>
+		</div>
+	</header>
+	<div id="modal_body" class="view-body">
+		<div class="stripe">
+			<div class="bounds">
+			... body content here ...
+			</div>
+		</div>
+	</div>
+</div>
+```
+*/
+/* TODO make demo page with code
+<div id="fullModal" class="view view--modal-full">
+	<header id="modal_header" class="view-head">
+		<div class="row inverted"> 
+			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
+			<img src="style/img/logo.svg" width="35" height="24"></a>
+			<div class="row-item row-item--alignMiddle viewHead-heading">
+				<h1 class="wrap--singleLine--truncate">Text post</h1> 
+			</div>
+			<div class="viewHead-actions row row-item row-item--shrink row-item--alignMiddle"> </div>
+		</div>
+	</header>
+	<div id="modal_body" class="view-body">
+		<div class="stripe">
+			<div class="bounds">
+				<div class="chunk">
+					<div class="row">
+						<div class="row-item--shrink">
+							<div class="avatar avatar--person avatar--small" style="background-image: url(http://api.randomuser.me/0.3/portraits/women/7.jpg);"></div>
+						</div> 
+						<div class="row-item">Sally Smeetup</div>
+					</div>
+				</div>
+				<div class="chunk">
+					<textarea id="post-textarea"></textarea>
+				</div>
+				<div class="chunk">
+					<div class="row">
+						<div class="row-item--shrink row-item--alignMiddle">
+							<a href="#" class="button button--primary">Post</a>
+						</div>
+						<div class="row-item row-item--alignMiddle">
+							<p class="text--caption">Visible to: members and non-members</p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+*/
 .view--modal-full {
   -webkit-transform: translate3d(0, 0, 0);
   -ms-transform: translate3d(0, 0, 0);
@@ -2634,6 +2751,81 @@ content container for the view.
     -ms-transform: translateY(100vh);
     transform: translateY(100vh); }
 
+/*doc
+---
+title: Snap Modal View (Dialog)
+name: snapModalView
+parent: modals
+---
+
+Modal that snaps to the whole viewport and is full screen on small screens,
+lays out as a dialog on background content on larger screens.
+
+```
+<div class="view view--modal-snap">
+	<header class="view-head">
+		<div class="row inverted"> 
+			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
+				Close
+			</a>
+			<div class="row-item row-item--alignMiddle viewHead-heading">
+				<h1 class="wrap--singleLine--truncate">Change your setting</h1> 
+			</div>
+		</div>
+	</header>
+	<div id="modal_body" class="view-body">
+		<div class="stripe">
+			<div class="bounds">
+			... body content here ...
+			
+			<button>Save</button>
+			</div>
+		</div>
+	</div>
+</div>
+```
+*/
+/* TODO demo page
+<div id="modal" class="view view--modal-snap">
+	<header id="modal_header" class="view-head">
+		<div class="row inverted"> 
+			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
+			<img src="style/img/logo.svg" width="35" height="24"></a>
+			<div class="row-item row-item--alignMiddle viewHead-heading">
+				<h1 class="wrap--singleLine--truncate">Text post</h1> 
+			</div>
+			<div class="viewHead-actions row row-item row-item--shrink row-item--alignMiddle"> </div>
+		</div>
+	</header>
+	<div id="modal_body" class="view-body">
+		<div class="stripe">
+			<div class="bounds">
+				<div class="chunk">
+					<div class="row">
+						<div class="row-item--shrink">
+							<div class="avatar avatar--person avatar--small" style="background-image: url(http://api.randomuser.me/0.3/portraits/women/7.jpg);"></div>
+						</div> 
+						<div class="row-item">Sally Smeetup</div>
+					</div>
+				</div>
+				<div class="chunk">
+					<textarea id="post-textarea"></textarea>
+				</div>
+				<div class="chunk">
+					<div class="row">
+						<div class="row-item--shrink row-item--alignMiddle">
+							<a href="#" class="button button--primary">Post</a>
+						</div>
+						<div class="row-item row-item--alignMiddle">
+							<p class="text--caption">Visible to: members and non-members</p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+*/
 .view--modal-snap {
   -webkit-transform: translate3d(0, 0, 0);
   -ms-transform: translate3d(0, 0, 0);

--- a/docs/build/css/sassquatch.css
+++ b/docs/build/css/sassquatch.css
@@ -2664,8 +2664,8 @@ category: Views
 
 Class                      | Description
 -------------------------- | ---------------------------
-`.view-modal--full`        | Makes a modal that is full screen on all screen sizes
-`.view-modal--snap`        | Creates a modal that is full screen on small sizes, overlay/dialog on larger screens
+`.view--modalFull`        | Makes a modal that is full screen on all screen sizes
+`.view--modalSnap`        | Creates a modal that is full screen on small sizes, overlay/dialog on larger screens
 
 
 */
@@ -2681,7 +2681,7 @@ Modal that is presented full screen on all sizes
 ```html_example
 <a class="link" href="pages/modal-full.html">Demo</a> 
 
-<div class="view view--modal-full display--none">
+<div class="view view--modalFull display--none">
 	<header class="view-head">
 		<div class="row inverted"> 
 			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
@@ -2703,7 +2703,7 @@ Modal that is presented full screen on all sizes
 ```
 
 */
-.view--modal-full {
+.view--modalFull {
   -webkit-transform: translate3d(0, 0, 0);
   -ms-transform: translate3d(0, 0, 0);
   transform: translate3d(0, 0, 0);
@@ -2717,7 +2717,7 @@ Modal that is presented full screen on all sizes
   top: 0;
   width: 100%;
   z-index: 3; }
-  .view--modal-full.off {
+  .view--modalFull.off {
     -webkit-transform: translateY(100vh);
     -ms-transform: translateY(100vh);
     transform: translateY(100vh); }
@@ -2736,7 +2736,7 @@ lays out as a dialog on background content on larger screens.
 ```html_example
 <a class="link" href="pages/modal-snap.html">Demo</a> 
 
-<div class="view view--modal-snap display--none">
+<div class="view view--modalSnap display--none">
 	<header class="view-head">
 		<div class="row inverted"> 
 			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
@@ -2759,7 +2759,7 @@ lays out as a dialog on background content on larger screens.
 </div>
 ```
 */
-.view--modal-snap {
+.view--modalSnap {
   -webkit-transform: translate3d(0, 0, 0);
   -ms-transform: translate3d(0, 0, 0);
   transform: translate3d(0, 0, 0);
@@ -2773,12 +2773,12 @@ lays out as a dialog on background content on larger screens.
   position: absolute;
   width: 440px;
   z-index: 3; }
-  .view--modal-snap.off {
+  .view--modalSnap.off {
     -webkit-transform: translateY(100vh);
     -ms-transform: translateY(100vh);
     transform: translateY(100vh); }
   @media only screen and (max-width: 440px) {
-    .view--modal-snap {
+    .view--modalSnap {
       -webkit-transform: translate3d(0, 0, 0);
       -ms-transform: translate3d(0, 0, 0);
       transform: translate3d(0, 0, 0);
@@ -2791,7 +2791,7 @@ lays out as a dialog on background content on larger screens.
       position: absolute;
       top: 0;
       width: 100%; }
-      .view--modal-snap.off {
+      .view--modalSnap.off {
         -webkit-transform: translateY(100vh);
         -ms-transform: translateY(100vh);
         transform: translateY(100vh); } }

--- a/docs/build/css/sassquatch.css
+++ b/docs/build/css/sassquatch.css
@@ -2499,7 +2499,8 @@ the "detail" responsibility.
   box-sizing: border-box;
   background: white;
   width: 100%;
-  min-height: 100vh; }
+  min-height: 100vh;
+  position: relative; }
 
 .view--splitList, .view--splitDetail {
   display: none; }
@@ -2555,7 +2556,6 @@ Class                      | Description
   background: #d55741;
   color: white;
   left: 0;
-  position: fixed;
   top: 0;
   width: 100%;
   z-index: 1;
@@ -2577,7 +2577,8 @@ Class                      | Description
 .view-head--transparent {
   background: transparent;
   border-bottom: none;
-  color: white; }
+  color: white;
+  position: absolute; }
   .view-head--photoOverlay h1,
   .view-head--transparent h1 {
     opacity: 0; }
@@ -2907,12 +2908,10 @@ _Ancestry only affects spacing in `attachment`. Text sizing remains explicit._
 @media only screen and (min-width: 640px) {
   .attachment.atMedium_stack--spread .stack-item,
   .attachment .atMedium_stack--spread .stack-item {
-    outline: 20px solid red;
     padding-left: 8px; } }
 @media only screen and (min-width: 840px) {
   .attachment.atLarge_stack--spread .stack-item,
   .attachment .atLarge_stack--spread .stack-item {
-    outline: 20px solid red;
     padding-left: 8px; } }
 .attachment.chunk,
 .attachment .chunk {
@@ -3256,8 +3255,11 @@ _(The inline style on the card element is for documentation purposes only)_
     right: -1px;
     top: -1px; }
 
+.card--event--past:before {
+  background: #e6e9ec; }
+
 .card--event--canceled:before {
-  background: #353e48; }
+  background: #e6e9ec; }
 
 .card--event--featured:before {
   background: #f0cb4f; }

--- a/docs/build/forms.html
+++ b/docs/build/forms.html
@@ -365,6 +365,13 @@ $(function() {
 		});
 	}
 
+
+	// TODO: modal code
+
+
+
+
+
 	//
 	// lunr search index
 	//
@@ -564,6 +571,36 @@ $(function() {
 					"title": "Clearfix placeholder",
 					"breadcrumb": "Sass Utils | Mixins & Placeholders > Clearfix placeholder",
 					"path": "sass_utils_|_mixins_&_placeholders.html#clearfix"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal mixins",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal mixins",
+					"path": "sass_utils_|_mixins_&_placeholders.html#modalUtils"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal Dialog Mixin",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal Dialog Mixin",
+					"path": "sass_utils_|_mixins_&_placeholders.html#Modal_Dialog_Mixin"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal Full Mixin",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal Full Mixin",
+					"path": "sass_utils_|_mixins_&_placeholders.html#Modal_Full_Mixin"
 				});
 
 			
@@ -1384,6 +1421,36 @@ $(function() {
 		
 	
 		
+			
+				
+				
+
+				index.add({
+					"title": "Modals",
+					"breadcrumb": "Views > Modals",
+					"path": "views.html#modals"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Full Modal View",
+					"breadcrumb": "Views > Full Modal View",
+					"path": "views.html#fullModalView"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Snap Modal View (Dialog)",
+					"breadcrumb": "Views > Snap Modal View (Dialog)",
+					"path": "views.html#snapModalView"
+				});
+
 			
 				
 				

--- a/docs/build/forms.html
+++ b/docs/build/forms.html
@@ -346,7 +346,8 @@ $(function() {
 	// Disable links by default
 	//
 	$('a').on("click", function(e) {
-		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+		debugger;
+		if ( this.getAttribute("href") == "#" || $(this).hasClass('noFollow') ) {
 			e.preventDefault();
 		}
 		return;
@@ -366,13 +367,6 @@ $(function() {
 			}
 		});
 	}
-
-
-	// TODO: modal code
-
-
-
-
 
 	//
 	// lunr search index

--- a/docs/build/forms.html
+++ b/docs/build/forms.html
@@ -129,17 +129,13 @@
 		</nav>
 
 	 	<main id="content" class="stack-item">
-<h1 id="checkbox">Checkboxes</h1>
-
-<p>A label variant class of <code>label--switch</code> is
-used for side-by-side inputs and labels.</p>
-
-<p>For radios and checkboxes, we put the <code>input</code>
-element inside the <code>label</code> element.</p>
-
-<p>A class of <code>checkbox</code> is <strong>required</strong> on checkbox
-input elements.</p>
-<div class="codeExample"><div class="exampleOutput"><label for="check1" class="label--switch chunk">
+<h1 id="checkbox" class="styleguide">Checkboxes</h1>
+<p class="styleguide">A label variant class of <code class="styleguide">label--switch</code> is
+used for side-by-side inputs and labels.</p><p class="styleguide">For radios and checkboxes, we put the <code class="styleguide">input</code>
+element inside the <code class="styleguide">label</code> element.</p><p class="styleguide">A class of <code class="styleguide">checkbox</code> is <strong>required</strong> on checkbox
+input elements.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <label for="check1" class="label--switch chunk">
     <input id="check1" class="checkbox" value="green" type="checkbox" />
     Green
 </label>
@@ -147,19 +143,28 @@ input elements.</p>
     <input id="check2" class="checkbox" value="blue" type="checkbox" />
     Blue
 </label>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;label</span> <span class="na">for=</span><span class="s">"check1"</span> <span class="na">class=</span><span class="s">"label--switch chunk"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;label</span> <span class="na">for=</span><span class="s">"check1"</span> <span class="na">class=</span><span class="s">"label--switch chunk"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;input</span> <span class="na">id=</span><span class="s">"check1"</span> <span class="na">class=</span><span class="s">"checkbox"</span> <span class="na">value=</span><span class="s">"green"</span> <span class="na">type=</span><span class="s">"checkbox"</span> <span class="nt">/&gt;</span>
     Green
 <span class="nt">&lt;/label&gt;</span>
 <span class="nt">&lt;label</span> <span class="na">for=</span><span class="s">"check2"</span> <span class="na">class=</span><span class="s">"label--switch chunk"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;input</span> <span class="na">id=</span><span class="s">"check2"</span> <span class="na">class=</span><span class="s">"checkbox"</span> <span class="na">value=</span><span class="s">"blue"</span> <span class="na">type=</span><span class="s">"checkbox"</span> <span class="nt">/&gt;</span>
     Blue
-<span class="nt">&lt;/label&gt;</span>
-</pre></div></div></div>
-<h1 id="forms">Basic Inputs</h1>
+<span class="nt">&lt;/label&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
+<h1 id="forms" class="styleguide">Basic Inputs</h1>
 
 <h2>Text inputs</h2>
-<div class="codeExample"><div class="exampleOutput"><div class="chunk">
+<div class="codeExample">
+  <div class="exampleOutput">
+    <div class="chunk">
     <label for="test-textinput">I'm a label</label>
     <input id="test-textinput" type="text" value="Text input with value" />
 </div>
@@ -199,7 +204,11 @@ input elements.</p>
         </select>
     </div>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"chunk"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"chunk"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;label</span> <span class="na">for=</span><span class="s">"test-textinput"</span><span class="nt">&gt;</span>I'm a label<span class="nt">&lt;/label&gt;</span>
     <span class="nt">&lt;input</span> <span class="na">id=</span><span class="s">"test-textinput"</span> <span class="na">type=</span><span class="s">"text"</span> <span class="na">value=</span><span class="s">"Text input with value"</span> <span class="nt">/&gt;</span>
 <span class="nt">&lt;/div&gt;</span>
@@ -238,66 +247,71 @@ input elements.</p>
             <span class="nt">&lt;option</span> <span class="na">value=</span><span class="s">"black"</span><span class="nt">&gt;</span>Seabreeze black<span class="nt">&lt;/option&gt;</span>
         <span class="nt">&lt;/select&gt;</span>
     <span class="nt">&lt;/div&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
-<h1 id="formValidation">Validation errors</h1>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<p>Error styles are applied to any child
-input of an element with the class <code>hasError</code>.</p>
-
-<p>Error text is set explicitly with <code>text--error</code>.</p>
-<div class="codeExample"><div class="exampleOutput"><div class="chunk hasError">
+<h1 id="formValidation" class="styleguide">Validation errors</h1>
+<p class="styleguide">Error styles are applied to any child
+input of an element with the class <code class="styleguide">hasError</code>.</p><p class="styleguide">Error text is set explicitly with <code class="styleguide">text--error</code>.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <div class="chunk hasError">
     <label for="test-textinput">First name</label>
     <input id="test-textinput" type="text" value="" />
     <p class="text--error">First name can't be empty</p>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"chunk hasError"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"chunk hasError"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;label</span> <span class="na">for=</span><span class="s">"test-textinput"</span><span class="nt">&gt;</span>First name<span class="nt">&lt;/label&gt;</span>
     <span class="nt">&lt;input</span> <span class="na">id=</span><span class="s">"test-textinput"</span> <span class="na">type=</span><span class="s">"text"</span> <span class="na">value=</span><span class="s">""</span> <span class="nt">/&gt;</span>
     <span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--error"</span><span class="nt">&gt;</span>First name can't be empty<span class="nt">&lt;/p&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
-<h1 id="launcher">Launcher</h1>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<p>Applies form field styles to an anchor, for use
-in launching custom input (ie. date/location pickers).</p>
-<div class="codeExample"><div class="exampleOutput"><div class="chunk">
+<h1 id="launcher" class="styleguide">Launcher</h1>
+<p class="styleguide">Applies form field styles to an anchor, for use
+in launching custom input (ie. date/location pickers).</p><div class="codeExample">
+  <div class="exampleOutput">
+    <div class="chunk">
     <label for="specialPicker2">Pick a location</label>
     <a id="specialPicker2" class="launcher" href="#">Boise, Idaho</a>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"chunk"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"chunk"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;label</span> <span class="na">for=</span><span class="s">"specialPicker2"</span><span class="nt">&gt;</span>Pick a location<span class="nt">&lt;/label&gt;</span>
     <span class="nt">&lt;a</span> <span class="na">id=</span><span class="s">"specialPicker2"</span> <span class="na">class=</span><span class="s">"launcher"</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>Boise, Idaho<span class="nt">&lt;/a&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
 <h2>Launcher variants</h2>
-
-<p>A class of <code>launcher</code> is <strong>required</strong> for launcher
-anchors. The following classes are optional variants</p>
-
-<table><thead>
-<tr>
+<p class="styleguide">A class of <code class="styleguide">launcher</code> is <strong>required</strong> for launcher
+anchors. The following classes are optional variants</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>launcher--placeholder</code></td>
+ <tr>
+<td><code class="styleguide">launcher--placeholder</code></td>
 <td>Applies placeholder-like text styles for &quot;unselected&quot; values</td>
 </tr>
-</tbody></table>
-
-<h1 id="radio">Radios</h1>
-
-<p>A label variant class of <code>label--switch</code> is
-used for side-by-side inputs and labels.</p>
-
-<p>For radios and checkboxes, we put the <code>input</code>
-element inside the <code>label</code> element.</p>
-
-<p>A class of <code>radio</code> is <strong>required</strong> on radio input
-elements.</p>
-<div class="codeExample"><div class="exampleOutput"><label for="radio1" class="label--switch chunk">
+ </table>
+<h1 id="radio" class="styleguide">Radios</h1>
+<p class="styleguide">A label variant class of <code class="styleguide">label--switch</code> is
+used for side-by-side inputs and labels.</p><p class="styleguide">For radios and checkboxes, we put the <code class="styleguide">input</code>
+element inside the <code class="styleguide">label</code> element.</p><p class="styleguide">A class of <code class="styleguide">radio</code> is <strong>required</strong> on radio input
+elements.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <label for="radio1" class="label--switch chunk">
     <input id="radio1" class="radio" name="radioExample" value="green" type="radio" />
     Green
 </label>
@@ -305,15 +319,22 @@ elements.</p>
     <input id="radio2" class="radio" name="radioExample" value="red" type="radio" />
     Red
 </label>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;label</span> <span class="na">for=</span><span class="s">"radio1"</span> <span class="na">class=</span><span class="s">"label--switch chunk"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;label</span> <span class="na">for=</span><span class="s">"radio1"</span> <span class="na">class=</span><span class="s">"label--switch chunk"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;input</span> <span class="na">id=</span><span class="s">"radio1"</span> <span class="na">class=</span><span class="s">"radio"</span> <span class="na">name=</span><span class="s">"radioExample"</span> <span class="na">value=</span><span class="s">"green"</span> <span class="na">type=</span><span class="s">"radio"</span> <span class="nt">/&gt;</span>
     Green
 <span class="nt">&lt;/label&gt;</span>
 <span class="nt">&lt;label</span> <span class="na">for=</span><span class="s">"radio2"</span> <span class="na">class=</span><span class="s">"label--switch chunk"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;input</span> <span class="na">id=</span><span class="s">"radio2"</span> <span class="na">class=</span><span class="s">"radio"</span> <span class="na">name=</span><span class="s">"radioExample"</span> <span class="na">value=</span><span class="s">"red"</span> <span class="na">type=</span><span class="s">"radio"</span> <span class="nt">/&gt;</span>
     Red
-<span class="nt">&lt;/label&gt;</span>
-</pre></div></div></div>	</main>
+<span class="nt">&lt;/label&gt;</span></pre>
+    </div>
+  </div>
+</div>
+	</main>
 	</section>
 
 <!-- lunr.js search index -->
@@ -600,16 +621,6 @@ $(function() {
 				
 
 				index.add({
-					"title": "Link color",
-					"breadcrumb": "Sass Utils | Mixins & Placeholders > Link color",
-					"path": "sass_utils_|_mixins_&_placeholders.html#linkColor"
-				});
-
-			
-				
-				
-
-				index.add({
 					"title": "Text protection shim",
 					"breadcrumb": "Sass Utils | Mixins & Placeholders > Text protection shim",
 					"path": "sass_utils_|_mixins_&_placeholders.html#textProtection"
@@ -684,8 +695,8 @@ $(function() {
 				
 
 				index.add({
-					"title": "Anchors & Buttons",
-					"breadcrumb": "Modifier Classes > Anchors & Buttons",
+					"title": "Anchors &amp; Buttons",
+					"breadcrumb": "Modifier Classes > Anchors &amp; Buttons",
 					"path": "modifier_classes.html#buttonMod"
 				});
 
@@ -1015,6 +1026,16 @@ $(function() {
 					"title": "Running text",
 					"breadcrumb": "Typography > Running text",
 					"path": "typography.html#runningText"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Link color",
+					"breadcrumb": "Typography > Link color",
+					"path": "typography.html#linkColor"
 				});
 
 			

--- a/docs/build/forms.html
+++ b/docs/build/forms.html
@@ -345,9 +345,11 @@ $(function() {
 	//
 	// Disable links by default
 	//
-	$('a').click(function(e) {
-		if ( $(this).hasClass('followLink') ) return;
-		e.preventDefault();
+	$('a').on("click", function(e) {
+		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+			e.preventDefault();
+		}
+		return;
 	});
 
 	//

--- a/docs/build/layout.html
+++ b/docs/build/layout.html
@@ -881,9 +881,11 @@ $(function() {
 	//
 	// Disable links by default
 	//
-	$('a').click(function(e) {
-		if ( $(this).hasClass('followLink') ) return;
-		e.preventDefault();
+	$('a').on("click", function(e) {
+		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+			e.preventDefault();
+		}
+		return;
 	});
 
 	//

--- a/docs/build/layout.html
+++ b/docs/build/layout.html
@@ -901,6 +901,13 @@ $(function() {
 		});
 	}
 
+
+	// TODO: modal code
+
+
+
+
+
 	//
 	// lunr search index
 	//
@@ -1100,6 +1107,36 @@ $(function() {
 					"title": "Clearfix placeholder",
 					"breadcrumb": "Sass Utils | Mixins & Placeholders > Clearfix placeholder",
 					"path": "sass_utils_|_mixins_&_placeholders.html#clearfix"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal mixins",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal mixins",
+					"path": "sass_utils_|_mixins_&_placeholders.html#modalUtils"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal Dialog Mixin",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal Dialog Mixin",
+					"path": "sass_utils_|_mixins_&_placeholders.html#Modal_Dialog_Mixin"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal Full Mixin",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal Full Mixin",
+					"path": "sass_utils_|_mixins_&_placeholders.html#Modal_Full_Mixin"
 				});
 
 			
@@ -1920,6 +1957,36 @@ $(function() {
 		
 	
 		
+			
+				
+				
+
+				index.add({
+					"title": "Modals",
+					"breadcrumb": "Views > Modals",
+					"path": "views.html#modals"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Full Modal View",
+					"breadcrumb": "Views > Full Modal View",
+					"path": "views.html#fullModalView"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Snap Modal View (Dialog)",
+					"breadcrumb": "Views > Snap Modal View (Dialog)",
+					"path": "views.html#snapModalView"
+				});
+
 			
 				
 				

--- a/docs/build/layout.html
+++ b/docs/build/layout.html
@@ -882,7 +882,8 @@ $(function() {
 	// Disable links by default
 	//
 	$('a').on("click", function(e) {
-		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+		debugger;
+		if ( this.getAttribute("href") == "#" || $(this).hasClass('noFollow') ) {
 			e.preventDefault();
 		}
 		return;
@@ -902,13 +903,6 @@ $(function() {
 			}
 		});
 	}
-
-
-	// TODO: modal code
-
-
-
-
 
 	//
 	// lunr search index

--- a/docs/build/layout.html
+++ b/docs/build/layout.html
@@ -194,14 +194,12 @@
 		</nav>
 
 	 	<main id="content" class="stack-item">
-<h1 id="bounds">Bounds</h1>
-
-<p>Used as a non-visual content container that manages content measure,
- Similar to <a href="http://meetup.github.io/sassquatch/doc_desktop/layout.html#docstar">sassquatch 1 <code>docBounds</code></a>.</p>
-
-<p>Centers children with auto margin, clears floats, applies
-padding, and sets a max-width.</p>
-<div class="codeExample"><div class="exampleOutput"><section class="stripe">
+<h1 id="bounds" class="styleguide">Bounds</h1>
+<p class="styleguide">Used as a non-visual content container that manages content measure,
+ Similar to <a class="styleguide" href="http://meetup.github.io/sassquatch/doc_desktop/layout.html#docstar" title="http://meetup.github.io/sassquatch/doc_desktop/layout.html#docstar">sassquatch 1 <code class="styleguide">docBounds</code></a>.</p><p class="styleguide">Centers children with auto margin, clears floats, applies
+padding, and sets a max-width.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <section class="stripe">
     <p>This is just a paragraph inside a stripe. There's no bounds element to center and set the measure of this text.</p>
 </section>
 
@@ -217,7 +215,11 @@ padding, and sets a max-width.</p>
         <p>This paragraph is inside a bounds. It enjoyes auto-margin and a max-width to ensure the type measure remains readable.</p>
     </div>
 </section>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;section</span> <span class="na">class=</span><span class="s">"stripe"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;section</span> <span class="na">class=</span><span class="s">"stripe"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;p&gt;</span>This is just a paragraph inside a stripe. There's no bounds element to center and set the measure of this text.<span class="nt">&lt;/p&gt;</span>
 <span class="nt">&lt;/section&gt;</span>
 
@@ -232,36 +234,35 @@ padding, and sets a max-width.</p>
         <span class="nt">&lt;p&gt;&lt;strong&gt;</span>Previous example, shaded to show detail<span class="nt">&lt;/strong&gt;&lt;/p&gt;</span>
         <span class="nt">&lt;p&gt;</span>This paragraph is inside a bounds. It enjoyes auto-margin and a max-width to ensure the type measure remains readable.<span class="nt">&lt;/p&gt;</span>
     <span class="nt">&lt;/div&gt;</span>
-<span class="nt">&lt;/section&gt;</span>
-</pre></div></div></div>
-<h2>Bounds variants</h2>
+<span class="nt">&lt;/section&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<table><thead>
-<tr>
+<h2>Bounds variants</h2>
+<table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.bounds</code></td>
+ <tr>
+<td><code class="styleguide">.bounds</code></td>
 <td>standard (narrow) bounds for any type of content</td>
 </tr>
 <tr>
-<td><code>.bounds--wide</code></td>
+<td><code class="styleguide">.bounds--wide</code></td>
 <td>bounds for wrapping wider content, such as gridList</td>
 </tr>
 <tr>
-<td><code>.bounds--sideHeader</code></td>
+<td><code class="styleguide">.bounds--sideHeader</code></td>
 <td>bounds for wrapping standard (narrow) content, offset by labels to the side at wide widths</td>
 </tr>
-</tbody></table>
-
+ </table>
 <h2>Side Header example</h2>
-
-<p>The <code>bounds--sideHeader</code> variant applies styles to accommodate a
-<code>bounds-header</code> element. A <code>bounds-header</code> is pulled to the left side
-of the bounds on wide screens (<code>large</code> breakpoint), and linearizes on small screens (less than <code>large</code>).</p>
-<div class="codeExample"><div class="exampleOutput">    <section class="stripe">
+<p class="styleguide">The <code class="styleguide">bounds--sideHeader</code> variant applies styles to accommodate a
+<code class="styleguide">bounds-header</code> element. A <code class="styleguide">bounds-header</code> is pulled to the left side
+of the bounds on wide screens (<code class="styleguide">large</code> breakpoint), and linearizes on small screens (less than <code class="styleguide">large</code>).</p><div class="codeExample">
+  <div class="exampleOutput">
+        <section class="stripe">
         <div class="bounds bounds--sideHeader">
 
             <div class="bounds-header chunk">
@@ -273,7 +274,11 @@ of the bounds on wide screens (<code>large</code> breakpoint), and linearizes on
             <p>You can apply the bounds-header class to a single element, or wrap a group of elements you'd like to pull to the side on large screens.</p>
         </div>
     </section>
-</div><div class="codeBlock"><div class="highlight"><pre>    <span class="nt">&lt;section</span> <span class="na">class=</span><span class="s">"stripe"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;section</span> <span class="na">class=</span><span class="s">"stripe"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"bounds bounds--sideHeader"</span><span class="nt">&gt;</span>
 
             <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"bounds-header chunk"</span><span class="nt">&gt;</span>
@@ -284,16 +289,17 @@ of the bounds on wide screens (<code>large</code> breakpoint), and linearizes on
             <span class="nt">&lt;p&gt;</span>This is just some content within the bounds, behaving like any other bounds content.<span class="nt">&lt;/p&gt;</span>
             <span class="nt">&lt;p&gt;</span>You can apply the bounds-header class to a single element, or wrap a group of elements you'd like to pull to the side on large screens.<span class="nt">&lt;/p&gt;</span>
         <span class="nt">&lt;/div&gt;</span>
-    <span class="nt">&lt;/section&gt;</span>
-</pre></div></div></div>
-<h1 id="chunk">Chunk</h1>
+    <span class="nt">&lt;/section&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<p>Adds bottom space to an element
-or a group of elements.</p>
-
-<p><em>Can be used in combination with any other component
-(ie. <code>class=&quot;row chunk&quot;</code>)</em></p>
-<div class="codeExample"><div class="exampleOutput"><div class="_DOC-SHADE chunk">
+<h1 id="chunk" class="styleguide">Chunk</h1>
+<p class="styleguide">Adds bottom space to an element
+or a group of elements.</p><p class="styleguide"><em>Can be used in combination with any other component
+(ie. <code class="styleguide">class=&quot;row chunk&quot;</code>)</em></p><div class="codeExample">
+  <div class="exampleOutput">
+    <div class="_DOC-SHADE chunk">
     <h2>Some heading</h2>
     <p>Some text</p>
     <p class="text--caption">Some kind of caption</p>
@@ -306,7 +312,11 @@ or a group of elements.</p>
     <p>Some text</p>
     <p class="text--caption">Some kind of caption</p>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"_DOC-SHADE chunk"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"_DOC-SHADE chunk"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;h2&gt;</span>Some heading<span class="nt">&lt;/h2&gt;</span>
     <span class="nt">&lt;p&gt;</span>Some text<span class="nt">&lt;/p&gt;</span>
     <span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--caption"</span><span class="nt">&gt;</span>Some kind of caption<span class="nt">&lt;/p&gt;</span>
@@ -318,14 +328,15 @@ or a group of elements.</p>
     <span class="nt">&lt;h2&gt;</span>Some heading<span class="nt">&lt;/h2&gt;</span>
     <span class="nt">&lt;p&gt;</span>Some text<span class="nt">&lt;/p&gt;</span>
     <span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--caption"</span><span class="nt">&gt;</span>Some kind of caption<span class="nt">&lt;/p&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
-<h1 id="exactList">Exact list</h1>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<p>Adaptive overflow control for inline block lists</p>
-
-<p><em>better docs TK</em></p>
-<div class="codeExample"><div class="exampleOutput"><div class="exactList">
+<h1 id="exactList" class="styleguide">Exact list</h1>
+<p class="styleguide">Adaptive overflow control for inline block lists</p><p class="styleguide"><em>better docs TK</em></p><div class="codeExample">
+  <div class="exampleOutput">
+    <div class="exactList">
     <ul class="inlineblockList exactList-content">
         <li><img src="https://placekitten.com/g/42/60" /></li>
         <li><img src="https://placekitten.com/g/42/60" /></li>
@@ -342,7 +353,11 @@ or a group of elements.</p>
         <li><img src="https://placekitten.com/g/42/60" /></li>
     </ul>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"exactList"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"exactList"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;ul</span> <span class="na">class=</span><span class="s">"inlineblockList exactList-content"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/42/60"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
         <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/42/60"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
@@ -358,137 +373,152 @@ or a group of elements.</p>
         <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/42/60"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
         <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/42/60"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
     <span class="nt">&lt;/ul&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
-<h1 id="flexRow">Row</h1>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<p>Arranges content in rows using <code>display: flex</code>.</p>
-
-<p>The <code>.row</code> class is applied to a wrapping element.</p>
-
-<p>Direct children of <code>.row</code> are flex children, and require
-a class of <code>.row-item</code> with an optional <code>.row-item--shirnk</code>
-for a flex-shrink item.</p>
-
-<p>The flex children in flex row do not have a <code>flex-basis</code> set; a
-basis is not required for most common layout tasks.</p>
-
-<p><em>Includes <code>table-cell</code> fallback for IE8.</em></p>
-
+<h1 id="flexRow" class="styleguide">Row</h1>
+<p class="styleguide">Arranges content in rows using <code class="styleguide">display: flex</code>.</p><p class="styleguide">The <code class="styleguide">.row</code> class is applied to a wrapping element.</p><p class="styleguide">Direct children of <code class="styleguide">.row</code> are flex children, and require
+a class of <code class="styleguide">.row-item</code> with an optional <code class="styleguide">.row-item--shirnk</code>
+for a flex-shrink item.</p><p class="styleguide">The flex children in flex row do not have a <code class="styleguide">flex-basis</code> set; a
+basis is not required for most common layout tasks.</p><p class="styleguide"><em>Includes <code class="styleguide">table-cell</code> fallback for IE8.</em></p>
 <h4>Examples:</h4>
-<div class="codeExample"><div class="exampleOutput"><div class="row">
+<div class="codeExample">
+  <div class="exampleOutput">
+    <div class="row">
     <div class="_DOC-SHADE row-item">Item 1</div>
     <div class="_DOC-SHADE row-item row-item--shrink">Item 2</div>
     <div class="_DOC-SHADE row-item row-item--shrink">Item 3</div>
     <div class="_DOC-SHADE row-item">Item 4</div>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"_DOC-SHADE row-item"</span><span class="nt">&gt;</span>Item 1<span class="nt">&lt;/div&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"_DOC-SHADE row-item row-item--shrink"</span><span class="nt">&gt;</span>Item 2<span class="nt">&lt;/div&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"_DOC-SHADE row-item row-item--shrink"</span><span class="nt">&gt;</span>Item 3<span class="nt">&lt;/div&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"_DOC-SHADE row-item"</span><span class="nt">&gt;</span>Item 4<span class="nt">&lt;/div&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div><div class="codeExample"><div class="exampleOutput"><div class="row">
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
+<div class="codeExample">
+  <div class="exampleOutput">
+    <div class="row">
     <div class="_DOC-SHADE row-item row-item--shrink">Item 1</div>
     <div class="_DOC-SHADE row-item">Item 2</div>
     <div class="_DOC-SHADE row-item row-item--shrink">Item 3</div>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"_DOC-SHADE row-item row-item--shrink"</span><span class="nt">&gt;</span>Item 1<span class="nt">&lt;/div&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"_DOC-SHADE row-item"</span><span class="nt">&gt;</span>Item 2<span class="nt">&lt;/div&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"_DOC-SHADE row-item row-item--shrink"</span><span class="nt">&gt;</span>Item 3<span class="nt">&lt;/div&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div><div class="codeExample"><div class="exampleOutput"><div class="row row--flexEnd">
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
+<div class="codeExample">
+  <div class="exampleOutput">
+    <div class="row row--flexEnd">
     <div class="_DOC-SHADE row-item row-item--shrink">Item 1</div>
     <div class="_DOC-SHADE row-item row-item--shrink">Item 2</div>
     <div class="_DOC-SHADE row-item row-item--shrink">Item 3</div>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row row--flexEnd"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row row--flexEnd"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"_DOC-SHADE row-item row-item--shrink"</span><span class="nt">&gt;</span>Item 1<span class="nt">&lt;/div&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"_DOC-SHADE row-item row-item--shrink"</span><span class="nt">&gt;</span>Item 2<span class="nt">&lt;/div&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"_DOC-SHADE row-item row-item--shrink"</span><span class="nt">&gt;</span>Item 3<span class="nt">&lt;/div&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div><div class="codeExample"><div class="exampleOutput"><div class="row row--spaceBetween row--reverse">
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
+<div class="codeExample">
+  <div class="exampleOutput">
+    <div class="row row--spaceBetween row--reverse">
     <div class="_DOC-SHADE row-item row-item--shrink">Item 1</div>
     <div class="_DOC-SHADE row-item row-item--shrink">Item 2</div>
     <div class="_DOC-SHADE row-item row-item--shrink">Item 3</div>
     <div class="_DOC-SHADE row-item row-item--shrink">Item 4</div>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row row--spaceBetween row--reverse"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row row--spaceBetween row--reverse"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"_DOC-SHADE row-item row-item--shrink"</span><span class="nt">&gt;</span>Item 1<span class="nt">&lt;/div&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"_DOC-SHADE row-item row-item--shrink"</span><span class="nt">&gt;</span>Item 2<span class="nt">&lt;/div&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"_DOC-SHADE row-item row-item--shrink"</span><span class="nt">&gt;</span>Item 3<span class="nt">&lt;/div&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"_DOC-SHADE row-item row-item--shrink"</span><span class="nt">&gt;</span>Item 4<span class="nt">&lt;/div&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
-<h2 id="flexrowItemVars">Row Item variants</h2>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<p>A class of <code>.row-item</code> is <strong>required</strong> on row items.
-The following classes are optional variants:</p>
-
-<table><thead>
-<tr>
+<h2 id="flexrowItemVars" class="styleguide">Row Item variants</h2>
+<p class="styleguide">A class of <code class="styleguide">.row-item</code> is <strong>required</strong> on row items.
+The following classes are optional variants:</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.row-item--shrink</code></td>
+ <tr>
+<td><code class="styleguide">.row-item--shrink</code></td>
 <td>Item shrinks to fit content</td>
 </tr>
 <tr>
-<td><code>.row-item--alignMiddle</code></td>
+<td><code class="styleguide">.row-item--alignMiddle</code></td>
 <td>Vertically aligns content to middle</td>
 </tr>
-</tbody></table>
-
-<h2 id="flexrowParent">Row variants</h2>
-
-<p>A class of <code>.row</code> is <strong>required</strong> on the flex row parent. The
-following classes are optional variants:</p>
-
-<table><thead>
-<tr>
+ </table>
+<h2 id="flexrowParent" class="styleguide">Row variants</h2>
+<p class="styleguide">A class of <code class="styleguide">.row</code> is <strong>required</strong> on the flex row parent. The
+following classes are optional variants:</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.row--noGutters</code></td>
-<td>removes padding from all <code>.row-item</code> children</td>
+ <tr>
+<td><code class="styleguide">.row--noGutters</code></td>
+<td>removes padding from all <code class="styleguide">.row-item</code> children</td>
 </tr>
 <tr>
-<td><code>.row--wrap</code></td>
+<td><code class="styleguide">.row--wrap</code></td>
 <td>allows row wrapping (useful for collapsing rows in smaller viewports)</td>
 </tr>
 <tr>
-<td><code>.row--reverse</code></td>
+<td><code class="styleguide">.row--reverse</code></td>
 <td>reverses row order</td>
 </tr>
 <tr>
-<td><code>.row--flexEnd</code></td>
-<td>justifies content to <code>flex-end</code></td>
+<td><code class="styleguide">.row--flexEnd</code></td>
+<td>justifies content to <code class="styleguide">flex-end</code></td>
 </tr>
 <tr>
-<td><code>.row--center</code></td>
-<td>justifies content to <code>center</code></td>
+<td><code class="styleguide">.row--center</code></td>
+<td>justifies content to <code class="styleguide">center</code></td>
 </tr>
 <tr>
-<td><code>.row--spaceBetween</code></td>
-<td>justifies content to <code>spaceBetween</code></td>
+<td><code class="styleguide">.row--spaceBetween</code></td>
+<td>justifies content to <code class="styleguide">spaceBetween</code></td>
 </tr>
 <tr>
-<td><code>.row--spaceAround</code></td>
-<td>justifies content to <code>spaceAround</code></td>
+<td><code class="styleguide">.row--spaceAround</code></td>
+<td>justifies content to <code class="styleguide">spaceAround</code></td>
 </tr>
-</tbody></table>
-
-<h1 id="gridList">Grid List</h1>
-
-<p>A grid layout with breakpoint specific numbers of items in each row.</p>
-
-<p>better docs TK</p>
-<div class="codeExample"><div class="exampleOutput"><ul class="gridList gridList--has1 atMedium_gridList--has3 atLarge_gridList--has4">
+ </table>
+<h1 id="gridList" class="styleguide">Grid List</h1>
+<p class="styleguide">A grid layout with breakpoint specific numbers of items in each row.</p><p class="styleguide">better docs TK</p><div class="codeExample">
+  <div class="exampleOutput">
+    <ul class="gridList gridList--has1 atMedium_gridList--has3 atLarge_gridList--has4">
     <li class="_DOC-SHADE">grid cell</li>
     <li class="_DOC-SHADE">grid cell</li>
     <li class="_DOC-SHADE">grid cell</li>
@@ -498,53 +528,52 @@ following classes are optional variants:</p>
     <li class="_DOC-SHADE">grid cell</li>
     <li class="_DOC-SHADE">grid cell</li>
 </ul>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;ul</span> <span class="na">class=</span><span class="s">"gridList gridList--has1 atMedium_gridList--has3 atLarge_gridList--has4"</span><span class="nt">&gt;</span>
-    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"_DOC-SHADE"</span><span class="nt">&gt;</span>grid cell<span class="nt">&lt;/li&gt;</span>
-    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"_DOC-SHADE"</span><span class="nt">&gt;</span>grid cell<span class="nt">&lt;/li&gt;</span>
-    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"_DOC-SHADE"</span><span class="nt">&gt;</span>grid cell<span class="nt">&lt;/li&gt;</span>
-    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"_DOC-SHADE"</span><span class="nt">&gt;</span>grid cell<span class="nt">&lt;/li&gt;</span>
-    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"_DOC-SHADE"</span><span class="nt">&gt;</span>grid cell<span class="nt">&lt;/li&gt;</span>
-    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"_DOC-SHADE"</span><span class="nt">&gt;</span>grid cell<span class="nt">&lt;/li&gt;</span>
-    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"_DOC-SHADE"</span><span class="nt">&gt;</span>grid cell<span class="nt">&lt;/li&gt;</span>
-    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"_DOC-SHADE"</span><span class="nt">&gt;</span>grid cell<span class="nt">&lt;/li&gt;</span>
-<span class="nt">&lt;/ul&gt;</span>
-</pre></div></div></div>
-<h2 id="gridListVariants">Grid List variants</h2>
 
-<p>A class of <code>gridList</code> is <strong>required</strong> on the gridList
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;ul</span> <span class="na">class=</span><span class="s">"gridList gridList--has1 atMedium_gridList--has3 atLarge_gridList--has4"</span><span class="nt">&gt;</span>
+    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"_DOC-SHADE"</span><span class="nt">&gt;</span>grid cell<span class="nt">&lt;/li&gt;</span>
+    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"_DOC-SHADE"</span><span class="nt">&gt;</span>grid cell<span class="nt">&lt;/li&gt;</span>
+    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"_DOC-SHADE"</span><span class="nt">&gt;</span>grid cell<span class="nt">&lt;/li&gt;</span>
+    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"_DOC-SHADE"</span><span class="nt">&gt;</span>grid cell<span class="nt">&lt;/li&gt;</span>
+    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"_DOC-SHADE"</span><span class="nt">&gt;</span>grid cell<span class="nt">&lt;/li&gt;</span>
+    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"_DOC-SHADE"</span><span class="nt">&gt;</span>grid cell<span class="nt">&lt;/li&gt;</span>
+    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"_DOC-SHADE"</span><span class="nt">&gt;</span>grid cell<span class="nt">&lt;/li&gt;</span>
+    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"_DOC-SHADE"</span><span class="nt">&gt;</span>grid cell<span class="nt">&lt;/li&gt;</span>
+<span class="nt">&lt;/ul&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
+<h2 id="gridListVariants" class="styleguide">Grid List variants</h2>
+<p class="styleguide">A class of <code class="styleguide">gridList</code> is <strong>required</strong> on the gridList
 parent element. By default, gridList creates a 2 column
-grid.</p>
-
-<p>The following classes are optional variants:</p>
-
-<table><thead>
-<tr>
+grid.</p><p class="styleguide">The following classes are optional variants:</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.gridList--photoGrid</code></td>
+ <tr>
+<td><code class="styleguide">.gridList--photoGrid</code></td>
 <td>Optimizes list item spacing for a grid of photos</td>
 </tr>
 <tr>
-<td><code>.gridList--has[n]</code></td>
-<td>Adjusts number of columns (ie. <code>.gridList--has4</code> creates a 4 column grid for all screen sizes)</td>
+<td><code class="styleguide">.gridList--has[n]</code></td>
+<td>Adjusts number of columns (ie. <code class="styleguide">.gridList--has4</code> creates a 4 column grid for all screen sizes)</td>
 </tr>
 <tr>
-<td><code>.atMedium_gridList--has[n]</code></td>
-<td>Sets number of columns for medium breakpoint and up (ie. <code>.atMedium_gridList--has6</code>)</td>
+<td><code class="styleguide">.atMedium_gridList--has[n]</code></td>
+<td>Sets number of columns for medium breakpoint and up (ie. <code class="styleguide">.atMedium_gridList--has6</code>)</td>
 </tr>
 <tr>
-<td><code>.atLarge_gridList--has[n]</code></td>
-<td>Sets number of columns for large breakpoint and up (ie. <code>.atLarge_gridList--has10</code>)</td>
+<td><code class="styleguide">.atLarge_gridList--has[n]</code></td>
+<td>Sets number of columns for large breakpoint and up (ie. <code class="styleguide">.atLarge_gridList--has10</code>)</td>
 </tr>
-</tbody></table>
-
-<h1 id="hscroll">Horizontal Scroll</h1>
-
-<p>Applies styles for horizontal scrolling lists.</p>
-<div class="codeExample"><div class="exampleOutput"><div class="hscroll">
+ </table>
+<h1 id="hscroll" class="styleguide">Horizontal Scroll</h1>
+<p class="styleguide">Applies styles for horizontal scrolling lists.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <div class="hscroll">
     <ul class="hscroll-content">
         <li><img src="https://placekitten.com/g/240/160" /></li>
         <li><img src="https://placekitten.com/g/240/160" /></li>
@@ -560,7 +589,11 @@ grid.</p>
         <li><img src="https://placekitten.com/g/240/160" /></li>
     </ul>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"hscroll"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"hscroll"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;ul</span> <span class="na">class=</span><span class="s">"hscroll-content"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/240/160"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
         <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/240/160"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
@@ -575,13 +608,16 @@ grid.</p>
         <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/240/160"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
         <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/240/160"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
     <span class="nt">&lt;/ul&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
-<h2>Media-conditional <code>hscroll</code></h2>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<p>It&#39;s possible to create an <code>hscroll</code> for small screens that expands
-into a non-scrolling list in the document flow for larger screens.</p>
-<div class="codeExample"><div class="exampleOutput"><div class="hscroll atMedium_hscroll--unclip">
+<h2>Media-conditional <code class="styleguide">hscroll</code></h2>
+<p class="styleguide">It&#39;s possible to create an <code class="styleguide">hscroll</code> for small screens that expands
+into a non-scrolling list in the document flow for larger screens.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <div class="hscroll atMedium_hscroll--unclip">
     <ul class="hscroll-content">
         <li><img src="https://placekitten.com/g/200/120" /></li>
         <li><img src="https://placekitten.com/g/200/120" /></li>
@@ -591,7 +627,11 @@ into a non-scrolling list in the document flow for larger screens.</p>
         <li><img src="https://placekitten.com/g/200/120" /></li>
     </ul>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"hscroll atMedium_hscroll--unclip"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"hscroll atMedium_hscroll--unclip"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;ul</span> <span class="na">class=</span><span class="s">"hscroll-content"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/200/120"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
         <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/200/120"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
@@ -600,51 +640,53 @@ into a non-scrolling list in the document flow for larger screens.</p>
         <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/200/120"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
         <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/200/120"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
     <span class="nt">&lt;/ul&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
-<p>A class of <code>hscroll</code> is <strong>required</strong>; the following classes are
-optional variants:</p>
-
-<table><thead>
-<tr>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
+<p class="styleguide">A class of <code class="styleguide">hscroll</code> is <strong>required</strong>; the following classes are
+optional variants:</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>atMedium_hscroll--unclip</code></td>
+ <tr>
+<td><code class="styleguide">atMedium_hscroll--unclip</code></td>
 <td>Allows visible overflow (as inline block list) at medium &amp; up</td>
 </tr>
 <tr>
-<td><code>atLarge_hscroll--unclip</code></td>
+<td><code class="styleguide">atLarge_hscroll--unclip</code></td>
 <td>Allows visible overflow (as inline block list) at large &amp; up</td>
 </tr>
-</tbody></table>
-
-<h1 id="inlineblockList">Inline-block list</h1>
-
-<p>Resets list styles; adds <code>display: inline-block</code> to
-each list item and right gutters between items.</p>
-<div class="codeExample"><div class="exampleOutput"><ul class="inlineblockList">
+ </table>
+<h1 id="inlineblockList" class="styleguide">Inline-block list</h1>
+<p class="styleguide">Resets list styles; adds <code class="styleguide">display: inline-block</code> to
+each list item and right gutters between items.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <ul class="inlineblockList">
     <li><img src="https://placekitten.com/g/72/72" alt="fluffy kitten" /></li>
     <li><img src="https://placekitten.com/g/72/72" alt="fluffy kitten" /></li>
     <li><img src="https://placekitten.com/g/72/72" alt="fluffy kitten" /></li>
     <li><img src="https://placekitten.com/g/72/72" alt="fluffy kitten" /></li>
 </ul>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;ul</span> <span class="na">class=</span><span class="s">"inlineblockList"</span><span class="nt">&gt;</span>
-    <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/72/72"</span> <span class="na">alt=</span><span class="s">"fluffy kitten"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
-    <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/72/72"</span> <span class="na">alt=</span><span class="s">"fluffy kitten"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
-    <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/72/72"</span> <span class="na">alt=</span><span class="s">"fluffy kitten"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
-    <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/72/72"</span> <span class="na">alt=</span><span class="s">"fluffy kitten"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
-<span class="nt">&lt;/ul&gt;</span>
-</pre></div></div></div>
-<h1 id="list">Divided list</h1>
 
-<p>Standard divided/spaced list; similar to
-an iOS table view.</p>
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;ul</span> <span class="na">class=</span><span class="s">"inlineblockList"</span><span class="nt">&gt;</span>
+    <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/72/72"</span> <span class="na">alt=</span><span class="s">"fluffy kitten"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
+    <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/72/72"</span> <span class="na">alt=</span><span class="s">"fluffy kitten"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
+    <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/72/72"</span> <span class="na">alt=</span><span class="s">"fluffy kitten"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
+    <span class="nt">&lt;li&gt;&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/72/72"</span> <span class="na">alt=</span><span class="s">"fluffy kitten"</span> <span class="nt">/&gt;&lt;/li&gt;</span>
+<span class="nt">&lt;/ul&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<p>Bottom spacing is provided with <code>chunk</code>.</p>
-<div class="codeExample"><div class="exampleOutput"><ul class="list">
+<h1 id="list" class="styleguide">Divided list</h1>
+<p class="styleguide">Standard divided/spaced list; similar to
+an iOS table view.</p><p class="styleguide">Bottom spacing is provided with <code class="styleguide">chunk</code>.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <ul class="list">
     <li class="list-item">
         <h2 class="chunk">Just a list item</h2>
     </li>
@@ -655,25 +697,32 @@ an iOS table view.</p>
         <h2 class="chunk">Just a list item</h2>
     </li>
 </ul>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;ul</span> <span class="na">class=</span><span class="s">"list"</span><span class="nt">&gt;</span>
-    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"list-item"</span><span class="nt">&gt;</span>
-        <span class="nt">&lt;h2</span> <span class="na">class=</span><span class="s">"chunk"</span><span class="nt">&gt;</span>Just a list item<span class="nt">&lt;/h2&gt;</span>
-    <span class="nt">&lt;/li&gt;</span>
-    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"list-item"</span><span class="nt">&gt;</span>
-        <span class="nt">&lt;h2</span> <span class="na">class=</span><span class="s">"chunk"</span><span class="nt">&gt;</span>Just a list item<span class="nt">&lt;/h2&gt;</span>
-    <span class="nt">&lt;/li&gt;</span>
-    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"list-item"</span><span class="nt">&gt;</span>
-        <span class="nt">&lt;h2</span> <span class="na">class=</span><span class="s">"chunk"</span><span class="nt">&gt;</span>Just a list item<span class="nt">&lt;/h2&gt;</span>
-    <span class="nt">&lt;/li&gt;</span>
-<span class="nt">&lt;/ul&gt;</span>
-</pre></div></div></div>
-<h1 id="stack">Stack</h1>
 
-<p>The <code>stack</code> layout tool is for elements that
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;ul</span> <span class="na">class=</span><span class="s">"list"</span><span class="nt">&gt;</span>
+    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"list-item"</span><span class="nt">&gt;</span>
+        <span class="nt">&lt;h2</span> <span class="na">class=</span><span class="s">"chunk"</span><span class="nt">&gt;</span>Just a list item<span class="nt">&lt;/h2&gt;</span>
+    <span class="nt">&lt;/li&gt;</span>
+    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"list-item"</span><span class="nt">&gt;</span>
+        <span class="nt">&lt;h2</span> <span class="na">class=</span><span class="s">"chunk"</span><span class="nt">&gt;</span>Just a list item<span class="nt">&lt;/h2&gt;</span>
+    <span class="nt">&lt;/li&gt;</span>
+    <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"list-item"</span><span class="nt">&gt;</span>
+        <span class="nt">&lt;h2</span> <span class="na">class=</span><span class="s">"chunk"</span><span class="nt">&gt;</span>Just a list item<span class="nt">&lt;/h2&gt;</span>
+    <span class="nt">&lt;/li&gt;</span>
+<span class="nt">&lt;/ul&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
+<h1 id="stack" class="styleguide">Stack</h1>
+<p class="styleguide">The <code class="styleguide">stack</code> layout tool is for elements that
 should be stacked in a column at small sizes,
 and spreads across horizontal space at a given
-breakpoint.</p>
-<div class="codeExample"><div class="exampleOutput"><div class="stack atLarge_stack--spread">
+breakpoint.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <div class="stack atLarge_stack--spread">
     <div class="stack-item stack-item--shrink _DOC-SHADE">
         <p>Stack Item (shrinks when spread)</p>
     </div>
@@ -681,59 +730,54 @@ breakpoint.</p>
         <p>Stack Item</p>
     </div>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"stack atLarge_stack--spread"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"stack atLarge_stack--spread"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"stack-item stack-item--shrink _DOC-SHADE"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;p&gt;</span>Stack Item (shrinks when spread)<span class="nt">&lt;/p&gt;</span>
     <span class="nt">&lt;/div&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"stack-item _DOC-SHADE"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;p&gt;</span>Stack Item<span class="nt">&lt;/p&gt;</span>
     <span class="nt">&lt;/div&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
-<h2>Stack variants</h2>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<p>A class of <code>stack</code> on the parent element is required.
+<h2>Stack variants</h2>
+<p class="styleguide">A class of <code class="styleguide">stack</code> on the parent element is required.
 Collapsing of the stack doesn&#39;t happen at any viewport
 size by default, so <strong>you must specify a spread point</strong>
-with one of the following classes.</p>
-
-<table><thead>
-<tr>
+with one of the following classes.</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>atMedium_stack--spread</code></td>
-<td>Spreads out the stack elements horizontally at <code>medium</code> breakpoint</td>
+ <tr>
+<td><code class="styleguide">atMedium_stack--spread</code></td>
+<td>Spreads out the stack elements horizontally at <code class="styleguide">medium</code> breakpoint</td>
 </tr>
 <tr>
-<td><code>atLarge_stack--spread</code></td>
-<td>Spreads out the stack elements horizontally at <code>large</code> breakpoint</td>
+<td><code class="styleguide">atLarge_stack--spread</code></td>
+<td>Spreads out the stack elements horizontally at <code class="styleguide">large</code> breakpoint</td>
 </tr>
-</tbody></table>
-
+ </table>
 <h2>stack-item variants</h2>
-
-<table><thead>
-<tr>
+<table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.stack-item--shrink</code></td>
+ <tr>
+<td><code class="styleguide">.stack-item--shrink</code></td>
 <td>Item shrinks to fit content <strong>only when spread</strong></td>
 </tr>
-</tbody></table>
-
-<h1 id="stripe">Stripe</h1>
-
-<p>A <code>.stipe</code> class should be applied to <code>&lt;section&gt;</code> elements
-to visually divide the page with stripes of color.</p>
-
-<p>To align content within a stripe, use <code>.bounds</code>.</p>
-<div class="codeExample"><div class="exampleOutput"><section class="stripe">
+ </table>
+<h1 id="stripe" class="styleguide">Stripe</h1>
+<p class="styleguide">A <code class="styleguide">.stipe</code> class should be applied to <code class="styleguide">&lt;section&gt;</code> elements
+to visually divide the page with stripes of color.</p><p class="styleguide">To align content within a stripe, use <code class="styleguide">.bounds</code>.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <section class="stripe">
     <div class="bounds">
         <p>... default stripe ...</p>
     </div>
@@ -750,7 +794,11 @@ to visually divide the page with stripes of color.</p>
         <p>... collection variant of stripe, used to contain collections of cards </p>
     </div>
 </section>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;section</span> <span class="na">class=</span><span class="s">"stripe"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;section</span> <span class="na">class=</span><span class="s">"stripe"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"bounds"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;p&gt;</span>... default stripe ...<span class="nt">&lt;/p&gt;</span>
     <span class="nt">&lt;/div&gt;</span>
@@ -766,54 +814,63 @@ to visually divide the page with stripes of color.</p>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"bounds"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;p&gt;</span>... collection variant of stripe, used to contain collections of cards <span class="nt">&lt;/p&gt;</span>
     <span class="nt">&lt;/div&gt;</span>
-<span class="nt">&lt;/section&gt;</span>
-</pre></div></div></div>
+<span class="nt">&lt;/section&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
 <h4>Stripe variants</h4>
-
-<p>A class of <code>.stripe</code> is required; the following classes are
-optional variants:</p>
-
-<table><thead>
-<tr>
+<p class="styleguide">A class of <code class="styleguide">.stripe</code> is required; the following classes are
+optional variants:</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.stripe--inverted</code></td>
-<td>applies the standard <code>$C_contentBGInverted</code> background color</td>
+ <tr>
+<td><code class="styleguide">.stripe--inverted</code></td>
+<td>applies the standard <code class="styleguide">$C_contentBGInverted</code> background color</td>
 </tr>
 <tr>
-<td><code>.stripe--collection</code></td>
+<td><code class="styleguide">.stripe--collection</code></td>
 <td>applies a light gray background; for use with card collections</td>
 </tr>
-</tbody></table>
-
-<h2 id="heroStripes">Hero Stripes</h2>
-
-<p>Special <code>stripe</code> variants are avaiable for
+ </table>
+<h2 id="heroStripes" class="styleguide">Hero Stripes</h2>
+<p class="styleguide">Special <code class="styleguide">stripe</code> variants are avaiable for
 &quot;hero&quot; header stripes.</p>
-
 <h3>Basic hero</h3>
-
-<p>Uses the <code>stripe--hero</code> variant.</p>
-<div class="codeExample"><div class="exampleOutput"><section class="stripe stripe--hero inverted">
+<p class="styleguide">Uses the <code class="styleguide">stripe--hero</code> variant.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <section class="stripe stripe--hero inverted">
     <h4>better example TK</h4>
 </section>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;section</span> <span class="na">class=</span><span class="s">"stripe stripe--hero inverted"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;section</span> <span class="na">class=</span><span class="s">"stripe stripe--hero inverted"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;h4&gt;</span>better example TK<span class="nt">&lt;/h4&gt;</span>
-<span class="nt">&lt;/section&gt;</span>
-</pre></div></div></div>
+<span class="nt">&lt;/section&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
 <h3>Photo hero</h3>
-
-<p>Uses the <code>stripe--photoHero</code> variant.</p>
-<div class="codeExample"><div class="exampleOutput"><section class="stripe stripe--photoHero inverted" style="background-image: url(http://photos2.meetupstatic.com/photos/event/4/a/2/9/600_434238985.jpeg);">
+<p class="styleguide">Uses the <code class="styleguide">stripe--photoHero</code> variant.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <section class="stripe stripe--photoHero inverted" style="background-image: url(http://photos2.meetupstatic.com/photos/event/4/a/2/9/600_434238985.jpeg);">
     <h4>better example TK</h4>
 </section>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;section</span> <span class="na">class=</span><span class="s">"stripe stripe--photoHero inverted"</span> <span class="na">style=</span><span class="s">"background-image: url(http://photos2.meetupstatic.com/photos/event/4/a/2/9/600_434238985.jpeg);"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;section</span> <span class="na">class=</span><span class="s">"stripe stripe--photoHero inverted"</span> <span class="na">style=</span><span class="s">"background-image: url(http://photos2.meetupstatic.com/photos/event/4/a/2/9/600_434238985.jpeg);"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;h4&gt;</span>better example TK<span class="nt">&lt;/h4&gt;</span>
-<span class="nt">&lt;/section&gt;</span>
-</pre></div></div></div>	</main>
+<span class="nt">&lt;/section&gt;</span></pre>
+    </div>
+  </div>
+</div>
+	</main>
 	</section>
 
 <!-- lunr.js search index -->
@@ -1100,16 +1157,6 @@ $(function() {
 				
 
 				index.add({
-					"title": "Link color",
-					"breadcrumb": "Sass Utils | Mixins & Placeholders > Link color",
-					"path": "sass_utils_|_mixins_&_placeholders.html#linkColor"
-				});
-
-			
-				
-				
-
-				index.add({
 					"title": "Text protection shim",
 					"breadcrumb": "Sass Utils | Mixins & Placeholders > Text protection shim",
 					"path": "sass_utils_|_mixins_&_placeholders.html#textProtection"
@@ -1184,8 +1231,8 @@ $(function() {
 				
 
 				index.add({
-					"title": "Anchors & Buttons",
-					"breadcrumb": "Modifier Classes > Anchors & Buttons",
+					"title": "Anchors &amp; Buttons",
+					"breadcrumb": "Modifier Classes > Anchors &amp; Buttons",
 					"path": "modifier_classes.html#buttonMod"
 				});
 
@@ -1515,6 +1562,16 @@ $(function() {
 					"title": "Running text",
 					"breadcrumb": "Typography > Running text",
 					"path": "typography.html#runningText"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Link color",
+					"breadcrumb": "Typography > Link color",
+					"path": "typography.html#linkColor"
 				});
 
 			

--- a/docs/build/modifier_classes.html
+++ b/docs/build/modifier_classes.html
@@ -609,7 +609,8 @@ $(function() {
 	// Disable links by default
 	//
 	$('a').on("click", function(e) {
-		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+		debugger;
+		if ( this.getAttribute("href") == "#" || $(this).hasClass('noFollow') ) {
 			e.preventDefault();
 		}
 		return;
@@ -629,13 +630,6 @@ $(function() {
 			}
 		});
 	}
-
-
-	// TODO: modal code
-
-
-
-
 
 	//
 	// lunr search index

--- a/docs/build/modifier_classes.html
+++ b/docs/build/modifier_classes.html
@@ -91,7 +91,7 @@
 									
 									
 										<li class="display--inline--mediumDown">
-											<a class="followLink" href="#buttonMod">Anchors & Buttons</a>
+											<a class="followLink" href="#buttonMod">Anchors &amp; Buttons</a>
 										</li>
 									
 
@@ -240,454 +240,364 @@
 		</nav>
 
 	 	<main id="content" class="stack-item">
-<h1 id="alignMod">Alignment</h1>
-
-<p><strong>Applies <code>!important</code> declaration</strong></p>
-
+<h1 id="alignMod" class="styleguide">Alignment</h1>
+<p class="styleguide"><strong>Applies <code class="styleguide">!important</code> declaration</strong></p>
 <h2>Text alignment</h2>
-
-<p>The following classes change the <code>text-align</code> of an element.</p>
-
-<table><thead>
-<tr>
+<p class="styleguide">The following classes change the <code class="styleguide">text-align</code> of an element.</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.align--left</code></td>
-<td>sets <code>text-align</code> to <code>left</code></td>
+ <tr>
+<td><code class="styleguide">.align--left</code></td>
+<td>sets <code class="styleguide">text-align</code> to <code class="styleguide">left</code></td>
 </tr>
 <tr>
-<td><code>.align--right</code></td>
-<td>sets <code>text-align</code> to <code>right</code></td>
+<td><code class="styleguide">.align--right</code></td>
+<td>sets <code class="styleguide">text-align</code> to <code class="styleguide">right</code></td>
 </tr>
 <tr>
-<td><code>.align--center</code></td>
-<td>sets <code>text-align</code> to <code>center</code></td>
+<td><code class="styleguide">.align--center</code></td>
+<td>sets <code class="styleguide">text-align</code> to <code class="styleguide">center</code></td>
 </tr>
-</tbody></table>
-
+ </table>
 <h2>Vertical alignment</h2>
-
-<p>The following classes adjust vertical centering of element
-contents.</p>
-
-<p>For elements displaying as <code>inline-block</code> or <code>table-cell</code>,
-the <code>vertical-align</code> property is used.</p>
-
-<p>For flex children, these classes set the <code>align-self</code> property
-to a value that best matches the <code>vertical-align</code> value.</p>
-
-<table><thead>
-<tr>
+<p class="styleguide">The following classes adjust vertical centering of element
+contents.</p><p class="styleguide">For elements displaying as <code class="styleguide">inline-block</code> or <code class="styleguide">table-cell</code>,
+the <code class="styleguide">vertical-align</code> property is used.</p><p class="styleguide">For flex children, these classes set the <code class="styleguide">align-self</code> property
+to a value that best matches the <code class="styleguide">vertical-align</code> value.</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.valign--baseline</code></td>
+ <tr>
+<td><code class="styleguide">.valign--baseline</code></td>
 <td>vertically centers element to baseline</td>
 </tr>
 <tr>
-<td><code>.valign--bottom</code></td>
+<td><code class="styleguide">.valign--bottom</code></td>
 <td>vertically centers element to bottom</td>
 </tr>
 <tr>
-<td><code>.valign--middle</code></td>
+<td><code class="styleguide">.valign--middle</code></td>
 <td>vertically centers element to middle</td>
 </tr>
 <tr>
-<td><code>.valign--top</code></td>
+<td><code class="styleguide">.valign--top</code></td>
 <td>vertically centers element to top</td>
 </tr>
-</tbody></table>
-
-<h1 id="animMod">Animation</h1>
-
-<p>Applies keyframes animation to element</p>
-
-<table><thead>
-<tr>
+ </table>
+<h1 id="animMod" class="styleguide">Animation</h1>
+<p class="styleguide">Applies keyframes animation to element</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.animate--bounceInSubtle</code></td>
+ <tr>
+<td><code class="styleguide">.animate--bounceInSubtle</code></td>
 <td>Applies bounce-in keyframes animation (plays once)</td>
 </tr>
 <tr>
-<td><code>.animate--spin</code></td>
+<td><code class="styleguide">.animate--spin</code></td>
 <td>Applies 360deg rotation keyframes (infinite)</td>
 </tr>
-</tbody></table>
+ </table>
+<h1 id="backgroundMod" class="styleguide">Background</h1>
 
-<h1 id="backgroundMod">Background</h1>
-
-<h2 id="imgFillMod">Image Fill</h2>
-
-<p>Sets background properties that center
+<h2 id="imgFillMod" class="styleguide">Image Fill</h2>
+<p class="styleguide">Sets background properties that center
 background image, set size to &#39;cover&#39;,
-and overflow hidden.</p>
-
-<p>Extends <code>%imgFill</code>.</p>
-
-<p>EXAMPLE TK</p>
-
-<h1 id="borderMod">Borders</h1>
-
-<p>Sets border properties on element</p>
-
-<table><thead>
-<tr>
+and overflow hidden.</p><p class="styleguide">Extends <code class="styleguide">%imgFill</code>.</p><p class="styleguide">EXAMPLE TK</p>
+<h1 id="borderMod" class="styleguide">Borders</h1>
+<p class="styleguide">Sets border properties on element</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.border--top</code></td>
+ <tr>
+<td><code class="styleguide">.border--top</code></td>
 <td>sets a standard top border on the element</td>
 </tr>
 <tr>
-<td><code>.border--none</code></td>
+<td><code class="styleguide">.border--none</code></td>
 <td>removes all borders from element</td>
 </tr>
 <tr>
-<td><code>.bordered</code></td>
+<td><code class="styleguide">.bordered</code></td>
 <td>sets a standard top border AND top padding</td>
 </tr>
-</tbody></table>
+ </table>
+<h1 id="buttonMod" class="styleguide">Anchors &amp; Buttons</h1>
 
-<h1 id="buttonMod">Anchors & Buttons</h1>
-
-<h2 id="buttonPersonalityMod">Button personality</h2>
-
-<p>Applies button-like pointer styles, text-decoration,
-and user-select.</p>
-<div class="codeExample"><div class="exampleOutput">    <a class="chunk display--block">I'm just an anchor, displayed block</a>
+<h2 id="buttonPersonalityMod" class="styleguide">Button personality</h2>
+<p class="styleguide">Applies button-like pointer styles, text-decoration,
+and user-select.</p><div class="codeExample">
+  <div class="exampleOutput">
+        <a class="chunk display--block">I'm just an anchor, displayed block</a>
     <a class="buttonPersonality chunk display--block">I behave more like a button (hover over me; try to select this text)</a>
-</div><div class="codeBlock"><div class="highlight"><pre>    <span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"chunk display--block"</span><span class="nt">&gt;</span>I'm just an anchor, displayed block<span class="nt">&lt;/a&gt;</span>
-    <span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"buttonPersonality chunk display--block"</span><span class="nt">&gt;</span>I behave more like a button (hover over me; try to select this text)<span class="nt">&lt;/a&gt;</span>
-</pre></div></div></div>
-<h1 id="displayMod">Display</h1>
 
-<p>Modifies display property of element</p>
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"chunk display--block"</span><span class="nt">&gt;</span>I'm just an anchor, displayed block<span class="nt">&lt;/a&gt;</span>
+    <span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"buttonPersonality chunk display--block"</span><span class="nt">&gt;</span>I behave more like a button (hover over me; try to select this text)<span class="nt">&lt;/a&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<table><thead>
-<tr>
+<h1 id="displayMod" class="styleguide">Display</h1>
+<p class="styleguide">Modifies display property of element</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.display--none</code></td>
-<td>sets <code>display</code> to <code>none</code></td>
+ <tr>
+<td><code class="styleguide">.display--none</code></td>
+<td>sets <code class="styleguide">display</code> to <code class="styleguide">none</code></td>
 </tr>
 <tr>
-<td><code>.display--block</code></td>
-<td>sets <code>display</code> to <code>block</code></td>
+<td><code class="styleguide">.display--block</code></td>
+<td>sets <code class="styleguide">display</code> to <code class="styleguide">block</code></td>
 </tr>
 <tr>
-<td><code>.display--inline</code></td>
-<td>sets <code>display</code> to <code>inline</code></td>
+<td><code class="styleguide">.display--inline</code></td>
+<td>sets <code class="styleguide">display</code> to <code class="styleguide">inline</code></td>
 </tr>
 <tr>
-<td><code>.display--inlineBlock</code></td>
-<td>sets <code>display</code> to <code>inlineblock</code></td>
+<td><code class="styleguide">.display--inlineBlock</code></td>
+<td>sets <code class="styleguide">display</code> to <code class="styleguide">inlineblock</code></td>
 </tr>
-</tbody></table>
-
-<h1 id="floatMod">Float</h1>
-
-<p>TK <code>.clearfix</code></p>
-
-<h1 id="jsMod">Javascript-conditional modifiers</h1>
-
-<p>Conditionally changes the display property of an element based
-javascript availability.</p>
-
-<p><em>Assumes a class of <code>hasJS</code> is added to the <code>body</code> tag with
-javascript on page load</em></p>
-
-<table><thead>
-<tr>
+ </table>
+<h1 id="floatMod" class="styleguide">Float</h1>
+<p class="styleguide">TK <code class="styleguide">.clearfix</code></p>
+<h1 id="jsMod" class="styleguide">Javascript-conditional modifiers</h1>
+<p class="styleguide">Conditionally changes the display property of an element based
+javascript availability.</p><p class="styleguide"><em>Assumes a class of <code class="styleguide">hasJS</code> is added to the <code class="styleguide">body</code> tag with
+javascript on page load</em></p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>hasJS_display--block</code></td>
-<td>Sets <code>display</code> property to <code>block</code> if user has JS</td>
+ <tr>
+<td><code class="styleguide">hasJS_display--block</code></td>
+<td>Sets <code class="styleguide">display</code> property to <code class="styleguide">block</code> if user has JS</td>
 </tr>
 <tr>
-<td><code>hasJS_display--inline</code></td>
-<td>Sets <code>display</code> property to <code>inline</code> if user has JS</td>
+<td><code class="styleguide">hasJS_display--inline</code></td>
+<td>Sets <code class="styleguide">display</code> property to <code class="styleguide">inline</code> if user has JS</td>
 </tr>
 <tr>
-<td><code>hasJS_display--inlineBlock</code></td>
-<td>Sets <code>display</code> property to <code>inline-block</code> if user has JS</td>
+<td><code class="styleguide">hasJS_display--inlineBlock</code></td>
+<td>Sets <code class="styleguide">display</code> property to <code class="styleguide">inline-block</code> if user has JS</td>
 </tr>
 <tr>
-<td><code>hasJS_display--none</code></td>
-<td>Sets <code>display</code> property to <code>none</code> if user has JS</td>
+<td><code class="styleguide">hasJS_display--none</code></td>
+<td>Sets <code class="styleguide">display</code> property to <code class="styleguide">none</code> if user has JS</td>
 </tr>
-</tbody></table>
-
-<h1 id="keepAspect">Aspect ratio helper</h1>
-
-<p>Maintains a given aspect ratio for flexible media.
-Apply to elements with background images.</p>
-
-<table><thead>
-<tr>
+ </table>
+<h1 id="keepAspect" class="styleguide">Aspect ratio helper</h1>
+<p class="styleguide">Maintains a given aspect ratio for flexible media.
+Apply to elements with background images.</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.keepAspect</code></td>
+ <tr>
+<td><code class="styleguide">.keepAspect</code></td>
 <td>maintains 1:1 aspect ratio when resized</td>
 </tr>
 <tr>
-<td><code>.keepAspect--16-9</code></td>
+<td><code class="styleguide">.keepAspect--16-9</code></td>
 <td>maintains 16:9 aspect ratio when resized</td>
 </tr>
 <tr>
-<td><code>.keepAspect--2-1</code></td>
+<td><code class="styleguide">.keepAspect--2-1</code></td>
 <td>maintains 2:1 aspect ratio when resized</td>
 </tr>
 <tr>
-<td><code>.keepAspect--2-3</code></td>
+<td><code class="styleguide">.keepAspect--2-3</code></td>
 <td>maintains 2:3 aspect ratio when resized</td>
 </tr>
 <tr>
-<td><code>.keepAspect--3-4</code></td>
+<td><code class="styleguide">.keepAspect--3-4</code></td>
 <td>maintains 3:4 aspect ratio when resized</td>
 </tr>
-</tbody></table>
-
-<h1 id="mediaMod">Media-conditional modifiers</h1>
-
-<p>Media-conditional modifiers allow us to apply
-a modification at a specific breakpoint.</p>
-
-<p><em>Uses atMediaUp</em></p>
-
+ </table>
+<h1 id="mediaMod" class="styleguide">Media-conditional modifiers</h1>
+<p class="styleguide">Media-conditional modifiers allow us to apply
+a modification at a specific breakpoint.</p><p class="styleguide"><em>Uses atMediaUp</em></p>
 <h4>Signature</h4>
-
-<p><code>.at[Breakpoint]_[property]--modification</code></p>
-
+<p class="styleguide"><code class="styleguide">.at[Breakpoint]_[property]--modification</code></p>
 <h4>Supported media and modifications</h4>
-
-<ul>
-<li><code>.at[ Medium | Large ]_align--[ center | right | left ]</code></li>
-<li><code>.at[ Medium | Large ]_display--[ none | inline | inlineBlock | block ]</code></li>
-<li><code>.at[ Medium | Large ]_border--[ none | top ]</code></li>
-<li><code>.at[ Medium | Large ]_padding--none</code></li>
-</ul>
-
-<p>Example TK</p>
-
-<h1 id="sizeMod">Media Sizing</h1>
-
-<p>Classes for applying dimensions to an element.</p>
-
-<table><thead>
-<tr>
+<ul class="styleguide"><li><code class="styleguide">.at[ Medium | Large ]_align--[ center | right | left ]</code></li>
+<li><code class="styleguide">.at[ Medium | Large ]_display--[ none | inline | inlineBlock | block ]</code></li>
+<li><code class="styleguide">.at[ Medium | Large ]_border--[ none | top ]</code></li>
+<li><code class="styleguide">.at[ Medium | Large ]_padding--none</code></li>
+</ul><p class="styleguide">Example TK</p>
+<h1 id="sizeMod" class="styleguide">Media Sizing</h1>
+<p class="styleguide">Classes for applying dimensions to an element.</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.media--xs</code></td>
-<td>Sets <code>width</code> to <code>$media-xs</code> and height to <code>auto</code></td>
+ <tr>
+<td><code class="styleguide">.media--xs</code></td>
+<td>Sets <code class="styleguide">width</code> to <code class="styleguide">$media-xs</code> and height to <code class="styleguide">auto</code></td>
 </tr>
 <tr>
-<td><code>.media--s</code></td>
-<td>Sets <code>width</code> to <code>$media-s</code> and height to <code>auto</code></td>
+<td><code class="styleguide">.media--s</code></td>
+<td>Sets <code class="styleguide">width</code> to <code class="styleguide">$media-s</code> and height to <code class="styleguide">auto</code></td>
 </tr>
 <tr>
-<td><code>.media--m</code></td>
-<td>Sets <code>width</code> to <code>$media-m</code> and height to <code>auto</code></td>
+<td><code class="styleguide">.media--m</code></td>
+<td>Sets <code class="styleguide">width</code> to <code class="styleguide">$media-m</code> and height to <code class="styleguide">auto</code></td>
 </tr>
 <tr>
-<td><code>.media--l</code></td>
-<td>Sets <code>width</code> to <code>$media-l</code> and height to <code>auto</code></td>
+<td><code class="styleguide">.media--l</code></td>
+<td>Sets <code class="styleguide">width</code> to <code class="styleguide">$media-l</code> and height to <code class="styleguide">auto</code></td>
 </tr>
 <tr>
-<td><code>.media--xl</code></td>
-<td>Sets <code>width</code> to <code>$media-xl</code> and height to <code>auto</code></td>
+<td><code class="styleguide">.media--xl</code></td>
+<td>Sets <code class="styleguide">width</code> to <code class="styleguide">$media-xl</code> and height to <code class="styleguide">auto</code></td>
 </tr>
-</tbody></table>
-
-<h1 id="spacingMod">Margin/Padding</h1>
-
-<p>Applies the standard unit of space as margin or padding
+ </table>
+<h1 id="spacingMod" class="styleguide">Margin/Padding</h1>
+<p class="styleguide">Applies the standard unit of space as margin or padding
 to an element.</p>
-
 <h2>Margin</h2>
-
-<table><thead>
-<tr>
+<table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.margin--top</code></td>
+ <tr>
+<td><code class="styleguide">.margin--top</code></td>
 <td>Adds top margin to element</td>
 </tr>
 <tr>
-<td><code>.margin--right</code></td>
+<td><code class="styleguide">.margin--right</code></td>
 <td>Adds right margin to element</td>
 </tr>
 <tr>
-<td><code>.margin--bottom</code></td>
+<td><code class="styleguide">.margin--bottom</code></td>
 <td>Adds bottom margin to element</td>
 </tr>
 <tr>
-<td><code>.margin--left</code></td>
+<td><code class="styleguide">.margin--left</code></td>
 <td>Adds left margin to element</td>
 </tr>
 <tr>
-<td><code>.margin--all</code></td>
+<td><code class="styleguide">.margin--all</code></td>
 <td>Adds margin to all sides of element</td>
 </tr>
 <tr>
-<td><code>.margin--none</code></td>
-<td>Sets <code>margin</code> to <code>0</code></td>
+<td><code class="styleguide">.margin--none</code></td>
+<td>Sets <code class="styleguide">margin</code> to <code class="styleguide">0</code></td>
 </tr>
-</tbody></table>
-
+ </table>
 <h2>Margin</h2>
-
-<table><thead>
-<tr>
+<table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.padding--top</code></td>
+ <tr>
+<td><code class="styleguide">.padding--top</code></td>
 <td>Adds top padding to element</td>
 </tr>
 <tr>
-<td><code>.padding--right</code></td>
+<td><code class="styleguide">.padding--right</code></td>
 <td>Adds right padding to element</td>
 </tr>
 <tr>
-<td><code>.padding--bottom</code></td>
+<td><code class="styleguide">.padding--bottom</code></td>
 <td>Adds bottom padding to element</td>
 </tr>
 <tr>
-<td><code>.padding--left</code></td>
+<td><code class="styleguide">.padding--left</code></td>
 <td>Adds left padding to element</td>
 </tr>
 <tr>
-<td><code>.padding--all</code></td>
+<td><code class="styleguide">.padding--all</code></td>
 <td>Adds padding to all sides of element</td>
 </tr>
 <tr>
-<td><code>.padding--none</code></td>
-<td>Sets <code>padding</code> to <code>0</code></td>
+<td><code class="styleguide">.padding--none</code></td>
+<td>Sets <code class="styleguide">padding</code> to <code class="styleguide">0</code></td>
 </tr>
-</tbody></table>
+ </table>
+<h1 id="textMod" class="styleguide">Text Modifiers</h1>
 
-<h1 id="textMod">Text Modifiers</h1>
-
-<h2 id="textDecoration">Text decoration</h2>
-
-<p>Basic text decoration</p>
-
-<table><thead>
-<tr>
+<h2 id="textDecoration" class="styleguide">Text decoration</h2>
+<p class="styleguide">Basic text decoration</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.text--strikethrough</code></td>
+ <tr>
+<td><code class="styleguide">.text--strikethrough</code></td>
 <td>strikethrough/strikeout/line-through</td>
 </tr>
-</tbody></table>
-
-<h2 id="textHideUtil">Hiding Text</h2>
-
-<p>To hide just the text node of an element, use
-the <code>text--hide</code> modifier.</p>
-
-<p>This is useful for links that only contain an
-SVG icon (use descriptive text for screen readers).</p>
-
-<p><em>(this class will not work on <code>inline</code> elements)</em></p>
-<div class="codeExample"><div class="exampleOutput"><a class="display--block text--hide" href="#">
+ </table>
+<h2 id="textHideUtil" class="styleguide">Hiding Text</h2>
+<p class="styleguide">To hide just the text node of an element, use
+the <code class="styleguide">text--hide</code> modifier.</p><p class="styleguide">This is useful for links that only contain an
+SVG icon (use descriptive text for screen readers).</p><p class="styleguide"><em>(this class will not work on <code class="styleguide">inline</code> elements)</em></p><div class="codeExample">
+  <div class="exampleOutput">
+    <a class="display--block text--hide" href="#">
     You can see the kitten, but you can't see this text.
     <img src="https://placekitten.com/g/32/32" />
 </a>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"display--block text--hide"</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"display--block text--hide"</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
     You can see the kitten, but you can't see this text.
     <span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"https://placekitten.com/g/32/32"</span> <span class="nt">/&gt;</span>
-<span class="nt">&lt;/a&gt;</span>
-</pre></div></div></div>
-<table><thead>
-<tr>
+<span class="nt">&lt;/a&gt;</span></pre>
+    </div>
+  </div>
+</div>
+<table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.text--hide</code></td>
+ <tr>
+<td><code class="styleguide">.text--hide</code></td>
 <td>Visually hides text; removes text from document flow</td>
 </tr>
-</tbody></table>
-
-<h2 id="typespaceMod">Type wrap/whitespace</h2>
-
-<p>Sets type wrapping, witespace, and overflow properties on element</p>
-
-<table><thead>
-<tr>
+ </table>
+<h2 id="typespaceMod" class="styleguide">Type wrap/whitespace</h2>
+<p class="styleguide">Sets type wrapping, witespace, and overflow properties on element</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.wrap--singleLine</code></td>
+ <tr>
+<td><code class="styleguide">.wrap--singleLine</code></td>
 <td>forces text to a single line (nowrap)</td>
 </tr>
 <tr>
-<td><code>.wrap--singleLine--truncate</code></td>
+<td><code class="styleguide">.wrap--singleLine--truncate</code></td>
 <td>forces text to a single line (nowrap) and truncates with &hellip;</td>
 </tr>
 <tr>
-<td><code>.matchLineHeight</code></td>
+<td><code class="styleguide">.matchLineHeight</code></td>
 <td>adds a small amount of top and bottom margin to a non-text element to match line height of nearby text</td>
 </tr>
-</tbody></table>
-
-<h2 id="wrapNiceUtil">Nice Hyphenation</h2>
-
-<p>Enables breaking all words and auto-hyphenation.</p>
-
-<table><thead>
-<tr>
+ </table>
+<h2 id="wrapNiceUtil" class="styleguide">Nice Hyphenation</h2>
+<p class="styleguide">Enables breaking all words and auto-hyphenation.</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.text--wrapNice</code></td>
+ <tr>
+<td><code class="styleguide">.text--wrapNice</code></td>
 <td>Visually hides text; removes text from document flow</td>
 </tr>
-</tbody></table>
+ </table>
+<h1 id="thumb" class="styleguide">Thumbnails</h1>
+<p class="styleguide">Sets background cover and position for photo thumbnails.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <div class="thumb media--l" style="background-image: url(http://photos4.meetupstatic.com/photos/member/d/0/2/c/member_156833292.jpeg);"></div>
 
-<h1 id="thumb">Thumbnails</h1>
-
-<p>Sets background cover and position for photo thumbnails.</p>
-<div class="codeExample"><div class="exampleOutput"><div class="thumb media--l" style="background-image: url(http://photos4.meetupstatic.com/photos/member/d/0/2/c/member_156833292.jpeg);"></div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"thumb media--l"</span> <span class="na">style=</span><span class="s">"background-image: url(http://photos4.meetupstatic.com/photos/member/d/0/2/c/member_156833292.jpeg);"</span><span class="nt">&gt;&lt;/div&gt;</span>
-</pre></div></div></div>	</main>
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"thumb media--l"</span> <span class="na">style=</span><span class="s">"background-image: url(http://photos4.meetupstatic.com/photos/member/d/0/2/c/member_156833292.jpeg);"</span><span class="nt">&gt;&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
+	</main>
 	</section>
 
 <!-- lunr.js search index -->
@@ -974,16 +884,6 @@ $(function() {
 				
 
 				index.add({
-					"title": "Link color",
-					"breadcrumb": "Sass Utils | Mixins & Placeholders > Link color",
-					"path": "sass_utils_|_mixins_&_placeholders.html#linkColor"
-				});
-
-			
-				
-				
-
-				index.add({
 					"title": "Text protection shim",
 					"breadcrumb": "Sass Utils | Mixins & Placeholders > Text protection shim",
 					"path": "sass_utils_|_mixins_&_placeholders.html#textProtection"
@@ -1058,8 +958,8 @@ $(function() {
 				
 
 				index.add({
-					"title": "Anchors & Buttons",
-					"breadcrumb": "Modifier Classes > Anchors & Buttons",
+					"title": "Anchors &amp; Buttons",
+					"breadcrumb": "Modifier Classes > Anchors &amp; Buttons",
 					"path": "modifier_classes.html#buttonMod"
 				});
 
@@ -1389,6 +1289,16 @@ $(function() {
 					"title": "Running text",
 					"breadcrumb": "Typography > Running text",
 					"path": "typography.html#runningText"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Link color",
+					"breadcrumb": "Typography > Link color",
+					"path": "typography.html#linkColor"
 				});
 
 			

--- a/docs/build/modifier_classes.html
+++ b/docs/build/modifier_classes.html
@@ -608,9 +608,11 @@ $(function() {
 	//
 	// Disable links by default
 	//
-	$('a').click(function(e) {
-		if ( $(this).hasClass('followLink') ) return;
-		e.preventDefault();
+	$('a').on("click", function(e) {
+		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+			e.preventDefault();
+		}
+		return;
 	});
 
 	//

--- a/docs/build/modifier_classes.html
+++ b/docs/build/modifier_classes.html
@@ -628,6 +628,13 @@ $(function() {
 		});
 	}
 
+
+	// TODO: modal code
+
+
+
+
+
 	//
 	// lunr search index
 	//
@@ -827,6 +834,36 @@ $(function() {
 					"title": "Clearfix placeholder",
 					"breadcrumb": "Sass Utils | Mixins & Placeholders > Clearfix placeholder",
 					"path": "sass_utils_|_mixins_&_placeholders.html#clearfix"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal mixins",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal mixins",
+					"path": "sass_utils_|_mixins_&_placeholders.html#modalUtils"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal Dialog Mixin",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal Dialog Mixin",
+					"path": "sass_utils_|_mixins_&_placeholders.html#Modal_Dialog_Mixin"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal Full Mixin",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal Full Mixin",
+					"path": "sass_utils_|_mixins_&_placeholders.html#Modal_Full_Mixin"
 				});
 
 			
@@ -1647,6 +1684,36 @@ $(function() {
 		
 	
 		
+			
+				
+				
+
+				index.add({
+					"title": "Modals",
+					"breadcrumb": "Views > Modals",
+					"path": "views.html#modals"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Full Modal View",
+					"breadcrumb": "Views > Full Modal View",
+					"path": "views.html#fullModalView"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Snap Modal View (Dialog)",
+					"breadcrumb": "Views > Snap Modal View (Dialog)",
+					"path": "views.html#snapModalView"
+				});
+
 			
 				
 				

--- a/docs/build/pages/modal-full.html
+++ b/docs/build/pages/modal-full.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<title>Sassquatch 2: Modal snap example</title>
+
+		<!-- Whitney -->
+		<link rel="stylesheet" href="http://static1.meetupstatic.com/fonts/whitney.css" type="text/css" />
+
+		<!-- Styleguide CSS -->
+		<link rel="stylesheet" href="../css/doc.css">
+		<link rel="stylesheet" href="../css/github.css">
+
+		<!-- CSS to be documented -->
+		<link rel="stylesheet" href="../css/sassquatch.css">
+		<script type="text/javascript" src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
+	</head>
+
+
+
+
+
+	<body>
+		<button id="demo" class="button button--primary">Show Me</button>	
+		<div id="modal" class="view view--modal-full display--none">
+			<header id="modal_header" class="view-head">
+				<div class="row inverted"> 
+					<div class="row-item row-item--alignMiddle viewHead-heading">
+						<h1 class="wrap--singleLine--truncate">Group Settings</h1> 
+					</div>
+					<div class="viewHead-actions row row-item row-item--shrink row-item--alignMiddle">
+						<a href="#" class="j-close">Close</a>
+					</div>
+				</div>
+			</header>
+			<div id="modal_body" class="view-body">
+				<div class="stripe">
+					<div class="bounds">
+						<div class="chunk">
+							<div class="row">
+								<div class="row-item--shrink">
+									<input type="checkbox" />
+								</div> 
+								<div class="row-item">Some Group Setting</div>
+							</div>
+						</div>
+						<div class="chunk">
+							<div class="row">
+								<div class="row-item--shrink">
+									<input type="checkbox" />
+								</div> 
+								<div class="row-item">Some Group Setting</div>
+							</div>
+						</div>
+						<div class="chunk">
+							<div class="row">
+								<div class="row-item--shrink">
+									<input type="checkbox" />
+								</div> 
+								<div class="row-item">Some Group Setting</div>
+							</div>
+						</div>
+						<div class="chunk">
+							<div class="row">
+								<div class="row-item--shrink">
+									<input type="checkbox" />
+								</div> 
+								<div class="row-item">Some Group Setting</div>
+							</div>
+						</div>
+						<div class="chunk">
+							<div class="row">
+								<div class="row-item--shrink">
+									<input type="checkbox" />
+								</div> 
+								<div class="row-item">Some Group Setting</div>
+							</div>
+						</div>
+						<div class="chunk">
+							<div class="row">
+								<div class="row-item--shrink row-item--alignMiddle">
+									<a href="#" class="button button--primary">Save</a>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<script>
+			$(function() {
+				$("#demo").on("click", function(e) {
+					e.preventDefault();
+					$("#modal").removeClass("display--none");
+
+				});	
+				$(".j-close").on("click", function(e) {
+					e.preventDefault();
+					$("#modal").addClass("display--none");
+				});
+			});
+		</script>
+	</body>
+</html>
+

--- a/docs/build/pages/modal-full.html
+++ b/docs/build/pages/modal-full.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 
-		<title>Sassquatch 2: Modal snap example</title>
+		<title>Sassquatch 2: Modal Full example</title>
 
 		<!-- Whitney -->
 		<link rel="stylesheet" href="http://static1.meetupstatic.com/fonts/whitney.css" type="text/css" />
@@ -24,7 +24,7 @@
 
 	<body>
 		<button id="demo" class="button button--primary">Show Me</button>	
-		<div id="modal" class="view view--modal-full display--none">
+		<div id="modal" class="view view--modalFull display--none">
 			<header id="modal_header" class="view-head">
 				<div class="row inverted"> 
 					<div class="row-item row-item--alignMiddle viewHead-heading">

--- a/docs/build/pages/modal-snap.html
+++ b/docs/build/pages/modal-snap.html
@@ -20,7 +20,7 @@
 
 	<body>
 		<button id="demo" class="button button--primary">Show Me</button>	
-		<div id="modal" class="view view--modal-snap display--none">
+		<div id="modal" class="view view--modalSnap display--none">
 			<header id="modal_header" class="view-head">
 				<div class="row inverted"> 
 					<div class="row-item row-item--alignMiddle viewHead-heading">

--- a/docs/build/pages/modal-snap.html
+++ b/docs/build/pages/modal-snap.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<title>Sassquatch 2: Modal snap example</title>
+
+		<!-- Whitney -->
+		<link rel="stylesheet" href="http://static1.meetupstatic.com/fonts/whitney.css" type="text/css" />
+
+		<!-- Styleguide CSS -->
+		<link rel="stylesheet" href="../css/doc.css">
+		<link rel="stylesheet" href="../css/github.css">
+
+		<!-- CSS to be documented -->
+		<link rel="stylesheet" href="../css/sassquatch.css">
+		<script type="text/javascript" src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
+	</head>
+
+	<body>
+		<button id="demo" class="button button--primary">Show Me</button>	
+		<div id="modal" class="view view--modal-snap display--none">
+			<header id="modal_header" class="view-head">
+				<div class="row inverted"> 
+					<div class="row-item row-item--alignMiddle viewHead-heading">
+						<h1 class="wrap--singleLine--truncate">Send a message...</h1> 
+					</div>
+					<div class="viewHead-actions row row-item row-item--shrink row-item--alignMiddle">
+						<a href="#" class="j-close">Close</a>
+					</div>
+				</div>
+			</header>
+			<div id="modal_body" class="view-body">
+				<div class="stripe">
+					<div class="bounds">
+						<div class="chunk">
+							<div class="row">
+								<div class="row-item--shrink">
+									<div class="avatar avatar--person avatar--small" style="background-image: url(http://api.randomuser.me/0.3/portraits/women/7.jpg);"></div>
+								</div> 
+								<div class="row-item">Sally Smeetup</div>
+							</div>
+						</div>
+						<div class="chunk">
+							<textarea id="post-textarea"></textarea>
+						</div>
+						<div class="chunk">
+							<div class="row">
+								<div class="row-item--shrink row-item--alignMiddle">
+									<a href="#" class="button button--primary">Post</a>
+								</div>
+								<div class="row-item row-item--alignMiddle">
+									<p class="text--caption">Visible to: members and non-members</p>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</body>
+	<script>
+		$(function() {
+			$("#demo").on("click", function(e) {
+				e.preventDefault();
+				$("#modal").removeClass("display--none");
+			});	
+			$(".j-close").on("click", function(e) {
+				e.preventDefault();
+				$("#modal").addClass("display--none");
+			});
+		});
+	</script>
+</html>
+
+

--- a/docs/build/sass_utils_|_functions.html
+++ b/docs/build/sass_utils_|_functions.html
@@ -184,9 +184,11 @@ $(function() {
 	//
 	// Disable links by default
 	//
-	$('a').click(function(e) {
-		if ( $(this).hasClass('followLink') ) return;
-		e.preventDefault();
+	$('a').on("click", function(e) {
+		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+			e.preventDefault();
+		}
+		return;
 	});
 
 	//

--- a/docs/build/sass_utils_|_functions.html
+++ b/docs/build/sass_utils_|_functions.html
@@ -185,7 +185,8 @@ $(function() {
 	// Disable links by default
 	//
 	$('a').on("click", function(e) {
-		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+		debugger;
+		if ( this.getAttribute("href") == "#" || $(this).hasClass('noFollow') ) {
 			e.preventDefault();
 		}
 		return;
@@ -205,13 +206,6 @@ $(function() {
 			}
 		});
 	}
-
-
-	// TODO: modal code
-
-
-
-
 
 	//
 	// lunr search index

--- a/docs/build/sass_utils_|_functions.html
+++ b/docs/build/sass_utils_|_functions.html
@@ -127,58 +127,53 @@
 		</nav>
 
 	 	<main id="content" class="stack-item">
-<h1 id="brightness">Contrast/brightness utils</h1>
+<h1 id="brightness" class="styleguide">Contrast/brightness utils</h1>
 
-<h2 id="getPerceivedBrightness">Perceived brightness value</h2>
-
-<p>Gets brightness of a color on a scale of 0-255 based on a yiq color space.
+<h2 id="getPerceivedBrightness" class="styleguide">Perceived brightness value</h2>
+<p class="styleguide">Gets brightness of a color on a scale of 0-255 based on a yiq color space.
 <em>Calculates green-weighted sum of RGB channels (green is perceived as brighter
-on additive color screens).</em></p>
-
-<p><em>returns int</em></p>
-<div class="codeBlock"><div class="highlight"><pre>getPerceivedBrightness(#000) // -&gt; 0
-</pre></div></div>
-<h2 id="getPrimaryTextColor">Programmatic contrast text</h2>
-
-<p>For a given background color, this function returns
-a text color value with appropriate contrast.</p>
-
-<p><em>returns <code>color</code> value</em></p>
-<div class="codeBlock"><div class="highlight"><pre>// -&gt; color: $C_textPrimaryInverted; (white text on dark)
+on additive color screens).</em></p><p class="styleguide"><em>returns int</em></p><div class="codeBlock">
+  <div class="highlight">
+    <pre>getPerceivedBrightness(#000) // -&gt; 0</pre>
+  </div>
+</div>
+<h2 id="getPrimaryTextColor" class="styleguide">Programmatic contrast text</h2>
+<p class="styleguide">For a given background color, this function returns
+a text color value with appropriate contrast.</p><p class="styleguide"><em>returns <code class="styleguide">color</code> value</em></p><div class="codeBlock">
+  <div class="highlight">
+    <pre>// -&gt; color: $C_textPrimaryInverted; (white text on dark)
 color: getPrimaryTextColor(#000);
 
 // -&gt; color: $C_textPrimary; (dark text on white)
-color: getPrimaryTextColor(#FFF);
-</pre></div></div>
-<h2 id="isDarkisLight">isDark/isLight</h2>
+color: getPrimaryTextColor(#FFF);</pre>
+  </div>
+</div>
+<h2 id="isDarkisLight" class="styleguide">isDark/isLight</h2>
+<p class="styleguide">Checks a given color for brightness and returns a boolean.
+Our default dark/light threshold is 160 on a scale of 0-255</p><p class="styleguide"><em>returns boolean</em></p><div class="codeBlock">
+  <div class="highlight">
+    <pre>isDark(#000) // -&gt; true
+isLight(#000) // -&gt; false</pre>
+  </div>
+</div>
+<h1 id="string" class="styleguide">String utils</h1>
 
-<p>Checks a given color for brightness and returns a boolean.
-Our default dark/light threshold is 160 on a scale of 0-255</p>
+<h2 id="str-firstCharToUpper" class="styleguide">str-firstCharToUpper</h2>
+<p class="styleguide">Capitalizes first letter of a given string. Useful as a camelCase converter.</p><p class="styleguide"><em>returns string</em></p><div class="codeBlock">
+  <div class="highlight">
+    <pre>str-firstCharToUpper('snowflake') // -&gt; 'Snowflake'
 
-<p><em>returns boolean</em></p>
-<div class="codeBlock"><div class="highlight"><pre>isDark(#000) // -&gt; true
-isLight(#000) // -&gt; false
-</pre></div></div>
-<h1 id="string">String utils</h1>
+.special#{str-firstCharToUpper('snowflake')} // -&gt; .specialSnowflake</pre>
+  </div>
+</div>
+<h2 id="str-replace" class="styleguide">str-replace</h2>
+<p class="styleguide">Search and replace on strings.</p><p class="styleguide"><em>returns string</em></p><div class="codeBlock">
+  <div class="highlight">
+    <pre>str-replace('inline-block', '-', '') // -&gt; 'inlineblock'
 
-<h2 id="str-firstCharToUpper">str-firstCharToUpper</h2>
-
-<p>Capitalizes first letter of a given string. Useful as a camelCase converter.</p>
-
-<p><em>returns string</em></p>
-<div class="codeBlock"><div class="highlight"><pre>str-firstCharToUpper('snowflake') // -&gt; 'Snowflake'
-
-.special#{str-firstCharToUpper('snowflake')} // -&gt; .specialSnowflake
-</pre></div></div>
-<h2 id="str-replace">str-replace</h2>
-
-<p>Search and replace on strings.</p>
-
-<p><em>returns string</em></p>
-<div class="codeBlock"><div class="highlight"><pre>str-replace('inline-block', '-', '') // -&gt; 'inlineblock'
-
-.display--#{str-replace('inline-block', '-block', 'Block')} -&gt; .display--inlineBlock
-</pre></div></div>	</main>
+.display--#{str-replace('inline-block', '-block', 'Block')} -&gt; .display--inlineBlock</pre>
+  </div>
+</div>	</main>
 	</section>
 
 <!-- lunr.js search index -->
@@ -465,16 +460,6 @@ $(function() {
 				
 
 				index.add({
-					"title": "Link color",
-					"breadcrumb": "Sass Utils | Mixins & Placeholders > Link color",
-					"path": "sass_utils_|_mixins_&_placeholders.html#linkColor"
-				});
-
-			
-				
-				
-
-				index.add({
 					"title": "Text protection shim",
 					"breadcrumb": "Sass Utils | Mixins & Placeholders > Text protection shim",
 					"path": "sass_utils_|_mixins_&_placeholders.html#textProtection"
@@ -549,8 +534,8 @@ $(function() {
 				
 
 				index.add({
-					"title": "Anchors & Buttons",
-					"breadcrumb": "Modifier Classes > Anchors & Buttons",
+					"title": "Anchors &amp; Buttons",
+					"breadcrumb": "Modifier Classes > Anchors &amp; Buttons",
 					"path": "modifier_classes.html#buttonMod"
 				});
 
@@ -880,6 +865,16 @@ $(function() {
 					"title": "Running text",
 					"breadcrumb": "Typography > Running text",
 					"path": "typography.html#runningText"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Link color",
+					"breadcrumb": "Typography > Link color",
+					"path": "typography.html#linkColor"
 				});
 
 			

--- a/docs/build/sass_utils_|_functions.html
+++ b/docs/build/sass_utils_|_functions.html
@@ -204,6 +204,13 @@ $(function() {
 		});
 	}
 
+
+	// TODO: modal code
+
+
+
+
+
 	//
 	// lunr search index
 	//
@@ -403,6 +410,36 @@ $(function() {
 					"title": "Clearfix placeholder",
 					"breadcrumb": "Sass Utils | Mixins & Placeholders > Clearfix placeholder",
 					"path": "sass_utils_|_mixins_&_placeholders.html#clearfix"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal mixins",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal mixins",
+					"path": "sass_utils_|_mixins_&_placeholders.html#modalUtils"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal Dialog Mixin",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal Dialog Mixin",
+					"path": "sass_utils_|_mixins_&_placeholders.html#Modal_Dialog_Mixin"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal Full Mixin",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal Full Mixin",
+					"path": "sass_utils_|_mixins_&_placeholders.html#Modal_Full_Mixin"
 				});
 
 			
@@ -1223,6 +1260,36 @@ $(function() {
 		
 	
 		
+			
+				
+				
+
+				index.add({
+					"title": "Modals",
+					"breadcrumb": "Views > Modals",
+					"path": "views.html#modals"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Full Modal View",
+					"breadcrumb": "Views > Full Modal View",
+					"path": "views.html#fullModalView"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Snap Modal View (Dialog)",
+					"breadcrumb": "Views > Snap Modal View (Dialog)",
+					"path": "views.html#snapModalView"
+				});
+
 			
 				
 				

--- a/docs/build/sass_utils_|_mixins_&_placeholders.html
+++ b/docs/build/sass_utils_|_mixins_&_placeholders.html
@@ -219,11 +219,6 @@
 									
 
 								
-
-									
-									
-
-								
 							</ul>
 						
 					</li>
@@ -267,209 +262,207 @@
 		</nav>
 
 	 	<main id="content" class="stack-item">
-<h1 id="align">Alignment Utilities</h1>
+<h1 id="align" class="styleguide">Alignment Utilities</h1>
 
-<h2 id="valign">Vertical-align children</h2>
+<h2 id="valign" class="styleguide">Vertical-align children</h2>
+<p class="styleguide"><strong>Try to avoid using for essential, non-decorative things</strong>
+Aligns children of selected element using flexbox.</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@extend %valignChildren;
+@extend %valignChildren--bottom;</pre>
+  </div>
+</div>
+<h1 id="animation" class="styleguide">Animation</h1>
 
-<p><strong>Try to avoid using for essential, non-decorative things</strong>
-Aligns children of selected element using flexbox.</p>
-<div class="codeBlock"><div class="highlight"><pre>@extend %valignChildren;
-@extend %valignChildren--bottom;
-</pre></div></div>
-<h1 id="animation">Animation</h1>
+<h2 id="bounce-in-subtle" class="styleguide">Subtle bounce-in</h2>
+<p class="styleguide">Subtle bounce effect using keyframes, provided via simple mixin
+<em>original keyframes generated with <a class="styleguide" href="http://goo.gl/tT4jnp" title="http://goo.gl/tT4jnp">Bounce.js</a></em></p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@include animate--bounce-in-subtle($time: 750ms);</pre>
+  </div>
+</div>
+<h2 id="spin" class="styleguide">Infinite spin</h2>
+<p class="styleguide">Infinite 2d rotation; 0-360deg.</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@include animate--spin($time: 0.8s);</pre>
+  </div>
+</div>
+<h1 id="background" class="styleguide">Background Utilities</h1>
 
-<h2 id="bounce-in-subtle">Subtle bounce-in</h2>
-
-<p>Subtle bounce effect using keyframes, provided via simple mixin
-<em>original keyframes generated with <a href="http://goo.gl/tT4jnp">Bounce.js</a></em></p>
-<div class="codeBlock"><div class="highlight"><pre>@include animate--bounce-in-subtle($time: 750ms);
-</pre></div></div>
-<h2 id="spin">Infinite spin</h2>
-
-<p>Infinite 2d rotation; 0-360deg.</p>
-<div class="codeBlock"><div class="highlight"><pre>@include animate--spin($time: 0.8s);
-</pre></div></div>
-<h1 id="background">Background Utilities</h1>
-
-<h2 id="backgroundClip">Background clip mixin</h2>
-
-<p>Sets background-clip property</p>
-<div class="codeBlock"><div class="highlight"><pre>@include background-clip($value: padding);
-@include background-clip('border');
-</pre></div></div>
-<h2 id="imgFill">Image fill placeholder</h2>
-
-<p>Sets background properties that center
+<h2 id="backgroundClip" class="styleguide">Background clip mixin</h2>
+<p class="styleguide">Sets background-clip property</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@include background-clip($value: padding);
+@include background-clip('border');</pre>
+  </div>
+</div>
+<h2 id="imgFill" class="styleguide">Image fill placeholder</h2>
+<p class="styleguide">Sets background properties that center
 background image, set size to &#39;cover&#39;,
-and overflow hidden.</p>
-
-<p><em>[ie. avatars][avatar]</em></p>
-<div class="codeBlock"><div class="highlight"><pre>@extend %imgFill;
-</pre></div></div>
-<h1 id="breakpoints">Media Query Breakpoints</h1>
+and overflow hidden.</p><p class="styleguide"><em><a class="styleguide" href="ui_components.html#avatar" title="ui_components.html#avatar">ie. avatars</a></em></p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@extend %imgFill;</pre>
+  </div>
+</div>
+<h1 id="breakpoints" class="styleguide">Media Query Breakpoints</h1>
 
 <h3>Mobile first mixin</h3>
-
-<p>This breakpoint mixin uses a <strong>mobile first</strong>
-strategy, meaning the <code>medium</code> breakpoint, for
-example, applies to <em>medium screens and larger</em>.</p>
-<div class="codeBlock"><div class="highlight"><pre>    @include atMediaUp(medium) {
+<p class="styleguide">This breakpoint mixin uses a <strong>mobile first</strong>
+strategy, meaning the <code class="styleguide">medium</code> breakpoint, for
+example, applies to <em>medium screens and larger</em>.</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@include atMediaUp(medium) {
         body::after {
             content: "medium screens and larger can see me";
         }
-    }
-</pre></div></div>
-<table><thead>
-<tr>
+    }</pre>
+  </div>
+</div><table class="styleguide"> <tr>
 <th>Breakpoint name</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>atMediaUp(small)</code></td>
+ <tr>
+<td><code class="styleguide">atMediaUp(small)</code></td>
 <td>Small sreens and up</td>
 </tr>
 <tr>
-<td><code>atMediaUp(medium)</code></td>
+<td><code class="styleguide">atMediaUp(medium)</code></td>
 <td>Landscape on most phones and up; portrait on some phablets</td>
 </tr>
 <tr>
-<td><code>atMediaUp(large)</code></td>
+<td><code class="styleguide">atMediaUp(large)</code></td>
 <td>Landscape on phabelts and up; portrait on most tablets or old desktops</td>
 </tr>
 <tr>
-<td><code>atMediaUp(huge)</code></td>
-<td>Modern desktop viewports and up or <a href="http://liliputing.com/wp-content/uploads/2013/10/fox-big-tablets.jpg">ridiculous huge tablets</a></td>
+<td><code class="styleguide">atMediaUp(huge)</code></td>
+<td>Modern desktop viewports and up or <a class="styleguide" href="http://liliputing.com/wp-content/uploads/2013/10/fox-big-tablets.jpg" title="http://liliputing.com/wp-content/uploads/2013/10/fox-big-tablets.jpg">ridiculous huge tablets</a></td>
 </tr>
-</tbody></table>
-
+ </table>
 <h3>Breaking for smaller sizes and under</h3>
-
-<p>In the event you need to target a <strong>specific screen size and under</strong>,
-use the <code>atMediaDown</code> mixin.</p>
-<div class="codeBlock"><div class="highlight"><pre>    @include atMediaDown(medium) {
+<p class="styleguide">In the event you need to target a <strong>specific screen size and under</strong>,
+use the <code class="styleguide">atMediaDown</code> mixin.</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@include atMediaDown(medium) {
         body::after {
             content: "medium screens and smaller can see me";
         }
-    }
-</pre></div></div>
-<table><thead>
-<tr>
+    }</pre>
+  </div>
+</div><table class="styleguide"> <tr>
 <th>Breakpoint name</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>atMediaDown(small)</code></td>
+ <tr>
+<td><code class="styleguide">atMediaDown(small)</code></td>
 <td>Small screens and under; portrait on most mobile devices</td>
 </tr>
 <tr>
-<td><code>atMediaDown(medium)</code></td>
+<td><code class="styleguide">atMediaDown(medium)</code></td>
 <td>Landscape on most phones and under; portrait on some phablets</td>
 </tr>
 <tr>
-<td><code>atMediaDown(large)</code></td>
+<td><code class="styleguide">atMediaDown(large)</code></td>
 <td>Landscape on phabelts and under; portrait on most tablets or old desktops</td>
 </tr>
 <tr>
-<td><code>atMediaDown(huge)</code></td>
+<td><code class="styleguide">atMediaDown(huge)</code></td>
 <td>Huge screens and under</td>
 </tr>
-</tbody></table>
+ </table>
+<h1 id="button" class="styleguide">Button utilities</h1>
 
-<h1 id="button">Button utilities</h1>
+<h2 id="buttonPersonality" class="styleguide">Button personality placeholder</h2>
+<p class="styleguide">Disables user-select, sets cursor, and resets text-decoration.</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@extend %buttonPersonality;</pre>
+  </div>
+</div>
+<h1 id="colorUtil" class="styleguide">Color</h1>
 
-<h2 id="buttonPersonality">Button personality placeholder</h2>
-
-<p>Disables user-select, sets cursor, and resets text-decoration.</p>
-<div class="codeBlock"><div class="highlight"><pre>@extend %buttonPersonality;
-</pre></div></div>
-<h1 id="colorUtil">Color</h1>
-
-<h2 id="colorAllMixin">SVG + Text color</h2>
-
-<p>Sets properties to apply color to SVG icons
-<em>and</em> text.</p>
-<div class="codeBlock"><div class="highlight"><pre>@mixin color-all($color: black);
-</pre></div></div>
-<h2 id="svgColorMixin">SVG color</h2>
-
-<p>Sets properties to color SVG icons</p>
-<div class="codeBlock"><div class="highlight"><pre>@mixin color-svg($color: black);
-</pre></div></div>
-<h1 id="datauri">data uri images</h1>
-
-<p>Sassquatch image dependencies are stored
-as data uris in a Sass map.</p>
-<div class="codeBlock"><div class="highlight"><pre>map-get($data-img-map, "orgBadge") // raw data uri
+<h2 id="colorAllMixin" class="styleguide">SVG + Text color</h2>
+<p class="styleguide">Sets properties to apply color to SVG icons
+<em>and</em> text.</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@mixin color-all($color: black);</pre>
+  </div>
+</div>
+<h2 id="svgColorMixin" class="styleguide">SVG color</h2>
+<p class="styleguide">Sets properties to color SVG icons</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@mixin color-svg($color: black);</pre>
+  </div>
+</div>
+<h1 id="datauri" class="styleguide">data uri images</h1>
+<p class="styleguide">Sassquatch image dependencies are stored
+as data uris in a Sass map.</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>map-get($data-img-map, "orgBadge") // raw data uri
 
 // OR
 
 .elWithImgBackground {
     @extend %backgroundImg--orgBadge; // sets background-image property
-}
-</pre></div></div>
-<table><thead>
-<tr>
+}</pre>
+  </div>
+</div><table class="styleguide"> <tr>
 <th>Img Name</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>orgBadge</code></td>
+ <tr>
+<td><code class="styleguide">orgBadge</code></td>
 <td>Organizer badge</td>
 </tr>
 <tr>
-<td><code>launcher</code></td>
+<td><code class="styleguide">launcher</code></td>
 <td>Form launcher input icon</td>
 </tr>
-</tbody></table>
+ </table>
+<h1 id="display" class="styleguide">Display utils</h1>
 
-<h1 id="display">Display utils</h1>
+<h2 id="pseudoDisplay" class="styleguide">Pseudo-element display mixin</h2>
+<p class="styleguide">Sets display property for psuedo-elements</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@include pseudoDisplay($value: block);</pre>
+  </div>
+</div>
+<h1 id="float" class="styleguide">Float utils</h1>
 
-<h2 id="pseudoDisplay">Pseudo-element display mixin</h2>
+<h2 id="clearfix" class="styleguide">Clearfix placeholder</h2>
+<p class="styleguide">Clears floated children.</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@extend %clearfix;</pre>
+  </div>
+</div>
+<h1 id="shadow" class="styleguide">Shadow utilities</h1>
 
-<p>Sets display property for psuedo-elements</p>
-<div class="codeBlock"><div class="highlight"><pre>@include pseudoDisplay($value: block);
-</pre></div></div>
-<h1 id="float">Float utils</h1>
+<h2 id="shadowPlaceholder" class="styleguide">Shadow placeholder</h2>
+<p class="styleguide">Applies standard box-shadow</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@extend %shadow;</pre>
+  </div>
+</div>
+<h1 id="shape" class="styleguide">Shapes</h1>
 
-<h2 id="clearfix">Clearfix placeholder</h2>
+<h2 id="circleMixin" class="styleguide">Circle mixin</h2>
+<p class="styleguide">Makes selected element a circle with border-radius</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@mixin circle($color: black, $size: 12px)</pre>
+  </div>
+</div>
+<h1 id="text" class="styleguide">Text utils</h1>
 
-<p>Clears floated children.</p>
-<div class="codeBlock"><div class="highlight"><pre>@extend %clearfix;
-</pre></div></div>
-<h1 id="shadow">Shadow utilities</h1>
-
-<h2 id="shadowPlaceholder">Shadow placeholder</h2>
-
-<p>Applies standard box-shadow</p>
-<div class="codeBlock"><div class="highlight"><pre>@extend %shadow;
-</pre></div></div>
-<h1 id="shape">Shapes</h1>
-
-<h2 id="circleMixin">Circle mixin</h2>
-
-<p>Makes selected element a circle with border-radius</p>
-<div class="codeBlock"><div class="highlight"><pre>@mixin circle($color: black, $size: 12px)
-</pre></div></div>
-<h1 id="text">Text utils</h1>
-
-<h2 id="linkColor">Link color</h2>
-
-<p>Forces an element to use link-like styling.</p>
-<div class="codeBlock"><div class="highlight"><pre>@extend %link;
-</pre></div></div>
-<h2 id="textProtection">Text protection shim</h2>
-
-<p>Adds a pseudo-element gradient</p>
-<div class="codeBlock"><div class="highlight"><pre>@mixin textProtectionScrim($placement: 'top'); // 'bottom' will place gradent on bottom of el
-</pre></div></div>
-<h2 id="textWrapUtil">Text wrap</h2>
-
-<p>Nice hyphenation and wrapping for running text.</p>
-<div class="codeBlock"><div class="highlight"><pre>@extend %link;
-</pre></div></div>	</main>
+<h2 id="textProtection" class="styleguide">Text protection shim</h2>
+<p class="styleguide">Adds a pseudo-element gradient</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@mixin textProtectionScrim($placement: 'top'); // 'bottom' will place gradent on bottom of el</pre>
+  </div>
+</div>
+<h2 id="textWrapUtil" class="styleguide">Text wrap</h2>
+<p class="styleguide">Nice hyphenation and wrapping for running text.</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@extend %link;</pre>
+  </div>
+</div>	</main>
 	</section>
 
 <!-- lunr.js search index -->
@@ -756,16 +749,6 @@ $(function() {
 				
 
 				index.add({
-					"title": "Link color",
-					"breadcrumb": "Sass Utils | Mixins & Placeholders > Link color",
-					"path": "sass_utils_|_mixins_&_placeholders.html#linkColor"
-				});
-
-			
-				
-				
-
-				index.add({
 					"title": "Text protection shim",
 					"breadcrumb": "Sass Utils | Mixins & Placeholders > Text protection shim",
 					"path": "sass_utils_|_mixins_&_placeholders.html#textProtection"
@@ -840,8 +823,8 @@ $(function() {
 				
 
 				index.add({
-					"title": "Anchors & Buttons",
-					"breadcrumb": "Modifier Classes > Anchors & Buttons",
+					"title": "Anchors &amp; Buttons",
+					"breadcrumb": "Modifier Classes > Anchors &amp; Buttons",
 					"path": "modifier_classes.html#buttonMod"
 				});
 
@@ -1171,6 +1154,16 @@ $(function() {
 					"title": "Running text",
 					"breadcrumb": "Typography > Running text",
 					"path": "typography.html#runningText"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Link color",
+					"breadcrumb": "Typography > Link color",
+					"path": "typography.html#linkColor"
 				});
 
 			

--- a/docs/build/sass_utils_|_mixins_&_placeholders.html
+++ b/docs/build/sass_utils_|_mixins_&_placeholders.html
@@ -176,6 +176,25 @@
 									
 									
 										<li class="display--inline--mediumDown">
+											<a class="followLink" href="#modalUtils">Modal mixins</a>
+										</li>
+									
+
+								
+
+									
+									
+
+								
+
+									
+									
+
+								
+
+									
+									
+										<li class="display--inline--mediumDown">
 											<a class="followLink" href="#shadow">Shadow utilities</a>
 										</li>
 									
@@ -433,6 +452,22 @@ as data uris in a Sass map.</p><div class="codeBlock">
     <pre>@extend %clearfix;</pre>
   </div>
 </div>
+<h1 id="modalUtils" class="styleguide">Modal mixins</h1>
+<p class="styleguide">Description here</p>
+<h2 id="Modal_Dialog_Mixin" class="styleguide">Modal Dialog Mixin</h2>
+<p class="styleguide">Use this mixin to get the behavior of a <a class="styleguide" href="views.html#snapModalView" title="views.html#snapModalView">link Snap Modal View</a>,
+a view that snaps to full page on small screens and a dialog on larger formats.</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@include modal-dialog;</pre>
+  </div>
+</div>
+<h2 id="Modal_Full_Mixin" class="styleguide">Modal Full Mixin</h2>
+<p class="styleguide">Use this mixin to get behavior of a full page modal.
+See <a class="styleguide" href="views.html#fullModalView" title="views.html#fullModalView">link the Full Modal View documentation</a></p><div class="codeBlock">
+  <div class="highlight">
+    <pre>@include modal-full;</pre>
+  </div>
+</div>
 <h1 id="shadow" class="styleguide">Shadow utilities</h1>
 
 <h2 id="shadowPlaceholder" class="styleguide">Shadow placeholder</h2>
@@ -492,6 +527,13 @@ $(function() {
 			}
 		});
 	}
+
+
+	// TODO: modal code
+
+
+
+
 
 	//
 	// lunr search index
@@ -692,6 +734,36 @@ $(function() {
 					"title": "Clearfix placeholder",
 					"breadcrumb": "Sass Utils | Mixins & Placeholders > Clearfix placeholder",
 					"path": "sass_utils_|_mixins_&_placeholders.html#clearfix"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal mixins",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal mixins",
+					"path": "sass_utils_|_mixins_&_placeholders.html#modalUtils"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal Dialog Mixin",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal Dialog Mixin",
+					"path": "sass_utils_|_mixins_&_placeholders.html#Modal_Dialog_Mixin"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal Full Mixin",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal Full Mixin",
+					"path": "sass_utils_|_mixins_&_placeholders.html#Modal_Full_Mixin"
 				});
 
 			
@@ -1512,6 +1584,36 @@ $(function() {
 		
 	
 		
+			
+				
+				
+
+				index.add({
+					"title": "Modals",
+					"breadcrumb": "Views > Modals",
+					"path": "views.html#modals"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Full Modal View",
+					"breadcrumb": "Views > Full Modal View",
+					"path": "views.html#fullModalView"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Snap Modal View (Dialog)",
+					"breadcrumb": "Views > Snap Modal View (Dialog)",
+					"path": "views.html#snapModalView"
+				});
+
 			
 				
 				

--- a/docs/build/sass_utils_|_mixins_&_placeholders.html
+++ b/docs/build/sass_utils_|_mixins_&_placeholders.html
@@ -455,7 +455,7 @@ as data uris in a Sass map.</p><div class="codeBlock">
 <h1 id="modalUtils" class="styleguide">Modal mixins</h1>
 <p class="styleguide">Description here</p>
 <h2 id="Modal_Dialog_Mixin" class="styleguide">Modal Dialog Mixin</h2>
-<p class="styleguide">Use this mixin to get the behavior of a <a class="styleguide" href="views.html#snapModalView" title="views.html#snapModalView">link Snap Modal View</a>,
+<p class="styleguide">Use this mixin to get the behavior of a <a class="styleguide" href="views.html#snapModalView" title="views.html#snapModalView">Snap Modal View</a>,
 a view that snaps to full page on small screens and a dialog on larger formats.</p><div class="codeBlock">
   <div class="highlight">
     <pre>@include modal-dialog;</pre>
@@ -463,7 +463,7 @@ a view that snaps to full page on small screens and a dialog on larger formats.<
 </div>
 <h2 id="Modal_Full_Mixin" class="styleguide">Modal Full Mixin</h2>
 <p class="styleguide">Use this mixin to get behavior of a full page modal.
-See <a class="styleguide" href="views.html#fullModalView" title="views.html#fullModalView">link the Full Modal View documentation</a></p><div class="codeBlock">
+See <a class="styleguide" href="views.html#fullModalView" title="views.html#fullModalView">the Full Modal View documentation</a></p><div class="codeBlock">
   <div class="highlight">
     <pre>@include modal-full;</pre>
   </div>
@@ -508,9 +508,11 @@ $(function() {
 	//
 	// Disable links by default
 	//
-	$('a').click(function(e) {
-		if ( $(this).hasClass('followLink') ) return;
-		e.preventDefault();
+	$('a').on("click", function(e) {
+		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+			e.preventDefault();
+		}
+		return;
 	});
 
 	//

--- a/docs/build/sass_utils_|_mixins_&_placeholders.html
+++ b/docs/build/sass_utils_|_mixins_&_placeholders.html
@@ -509,7 +509,8 @@ $(function() {
 	// Disable links by default
 	//
 	$('a').on("click", function(e) {
-		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+		debugger;
+		if ( this.getAttribute("href") == "#" || $(this).hasClass('noFollow') ) {
 			e.preventDefault();
 		}
 		return;
@@ -529,13 +530,6 @@ $(function() {
 			}
 		});
 	}
-
-
-	// TODO: modal code
-
-
-
-
 
 	//
 	// lunr search index

--- a/docs/build/typography.html
+++ b/docs/build/typography.html
@@ -473,7 +473,8 @@ $(function() {
 	// Disable links by default
 	//
 	$('a').on("click", function(e) {
-		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+		debugger;
+		if ( this.getAttribute("href") == "#" || $(this).hasClass('noFollow') ) {
 			e.preventDefault();
 		}
 		return;
@@ -493,13 +494,6 @@ $(function() {
 			}
 		});
 	}
-
-
-	// TODO: modal code
-
-
-
-
 
 	//
 	// lunr search index

--- a/docs/build/typography.html
+++ b/docs/build/typography.html
@@ -118,6 +118,11 @@
 
 									
 									
+
+								
+
+									
+									
 										<li class="display--inline--mediumDown">
 											<a class="followLink" href="#headings">Headings</a>
 										</li>
@@ -162,84 +167,146 @@
 		</nav>
 
 	 	<main id="content" class="stack-item">
-<h1 id="bodyText">Body/primary text</h1>
-<div class="codeExample"><div class="exampleOutput"><p>This is default body text, inheritied from type styles applied to &lt;body&gt;</p>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;p&gt;</span>This is default body text, inheritied from type styles applied to <span class="ni">&amp;lt;</span>body<span class="ni">&amp;gt;</span><span class="nt">&lt;/p&gt;</span>
-</pre></div></div></div>
-<h2 id="boldText">Bold text</h2>
-<div class="codeExample"><div class="exampleOutput"><p class="text--bold">Bold text is bold</p>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--bold"</span><span class="nt">&gt;</span>Bold text is bold<span class="nt">&lt;/p&gt;</span>
-</pre></div></div></div>
-<h2 id="bulletedList">Bulleted lists</h2>
+<h1 id="bodyText" class="styleguide">Body/primary text</h1>
+<div class="codeExample">
+  <div class="exampleOutput">
+    <p>This is default body text, inheritied from type styles applied to &lt;body&gt;</p>
 
-<p><code>&lt;ul&gt;</code> and <code>&lt;ol&gt;</code> element list styles are
-reset by default.</p>
-<div class="codeExample"><div class="exampleOutput"><ul>
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;p&gt;</span>This is default body text, inheritied from type styles applied to <span class="ni">&amp;lt;</span>body<span class="ni">&amp;gt;</span><span class="nt">&lt;/p&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
+<h2 id="boldText" class="styleguide">Bold text</h2>
+<div class="codeExample">
+  <div class="exampleOutput">
+    <p class="text--bold">Bold text is bold</p>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--bold"</span><span class="nt">&gt;</span>Bold text is bold<span class="nt">&lt;/p&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
+<h2 id="bulletedList" class="styleguide">Bulleted lists</h2>
+<p class="styleguide"><code class="styleguide">&lt;ul&gt;</code> and <code class="styleguide">&lt;ol&gt;</code> element list styles are
+reset by default.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <ul>
     <li>Eggs</li>
     <li>More Eggs</li>
 </ul>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;ul&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;ul&gt;</span>
     <span class="nt">&lt;li&gt;</span>Eggs<span class="nt">&lt;/li&gt;</span>
     <span class="nt">&lt;li&gt;</span>More Eggs<span class="nt">&lt;/li&gt;</span>
-<span class="nt">&lt;/ul&gt;</span>
-</pre></div></div></div>
-<p>List style bullets are applied when list
-elements are inside a <code>.runningText</code> container.</p>
-<div class="codeExample"><div class="exampleOutput"><div class="runningText">
+<span class="nt">&lt;/ul&gt;</span></pre>
+    </div>
+  </div>
+</div>
+<p class="styleguide">List style bullets are applied when list
+elements are inside a <code class="styleguide">.runningText</code> container.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <div class="runningText">
     <ul>
         <li>Eggs</li>
         <li>More Eggs</li>
     </ul>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"runningText"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"runningText"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;ul&gt;</span>
         <span class="nt">&lt;li&gt;</span>Eggs<span class="nt">&lt;/li&gt;</span>
         <span class="nt">&lt;li&gt;</span>More Eggs<span class="nt">&lt;/li&gt;</span>
     <span class="nt">&lt;/ul&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
-<p>You may also use the <code>.bullets</code> class to apply
-numbers/bullets to a list.</p>
-<div class="codeExample"><div class="exampleOutput"><ul class="bullets">
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
+<p class="styleguide">You may also use the <code class="styleguide">.bullets</code> class to apply
+numbers/bullets to a list.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <ul class="bullets">
     <li>Eggs</li>
     <li>More Eggs</li>
 </ul>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;ul</span> <span class="na">class=</span><span class="s">"bullets"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;ul</span> <span class="na">class=</span><span class="s">"bullets"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;li&gt;</span>Eggs<span class="nt">&lt;/li&gt;</span>
     <span class="nt">&lt;li&gt;</span>More Eggs<span class="nt">&lt;/li&gt;</span>
-<span class="nt">&lt;/ul&gt;</span>
-</pre></div></div></div>
-<h2 id="captionText">Caption text</h2>
-<div class="codeExample"><div class="exampleOutput"><p class="text--caption">I'm captioning all the things</p>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--caption"</span><span class="nt">&gt;</span>I'm captioning all the things<span class="nt">&lt;/p&gt;</span>
-</pre></div></div></div>
-<h2 id="hintText">Hint text</h2>
-<div class="codeExample"><div class="exampleOutput"><p class="text--hint">This is hint text</p>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--hint"</span><span class="nt">&gt;</span>This is hint text<span class="nt">&lt;/p&gt;</span>
-</pre></div></div></div>
-<h2 id="invertedText">Inverted text</h2>
+<span class="nt">&lt;/ul&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<p>Apply the <code>inverted</code> class to a container with
+<h2 id="captionText" class="styleguide">Caption text</h2>
+<div class="codeExample">
+  <div class="exampleOutput">
+    <p class="text--caption">I'm captioning all the things</p>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--caption"</span><span class="nt">&gt;</span>I'm captioning all the things<span class="nt">&lt;/p&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
+<h2 id="hintText" class="styleguide">Hint text</h2>
+<div class="codeExample">
+  <div class="exampleOutput">
+    <p class="text--hint">This is hint text</p>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--hint"</span><span class="nt">&gt;</span>This is hint text<span class="nt">&lt;/p&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
+<h2 id="invertedText" class="styleguide">Inverted text</h2>
+<p class="styleguide">Apply the <code class="styleguide">inverted</code> class to a container with
 a dark background color or photo to flip all text
-elements to inveted colors.</p>
-<div class="codeExample"><div class="exampleOutput"><div style="background: #353E48;" class="inverted">
+elements to inveted colors.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <div style="background: #353E48;" class="inverted">
     <p>This is default body text, inheritied from type styles applied to &lt;body&gt;</p>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">style=</span><span class="s">"background: #353E48;"</span> <span class="na">class=</span><span class="s">"inverted"</span><span class="nt">&gt;</span>
-    <span class="nt">&lt;p&gt;</span>This is default body text, inheritied from type styles applied to <span class="ni">&amp;lt;</span>body<span class="ni">&amp;gt;</span><span class="nt">&lt;/p&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
-<h2 id="runningText">Running text</h2>
 
-<p>By default, paragraphs and headings are not styled
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">style=</span><span class="s">"background: #353E48;"</span> <span class="na">class=</span><span class="s">"inverted"</span><span class="nt">&gt;</span>
+    <span class="nt">&lt;p&gt;</span>This is default body text, inheritied from type styles applied to <span class="ni">&amp;lt;</span>body<span class="ni">&amp;gt;</span><span class="nt">&lt;/p&gt;</span>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
+<h2 id="runningText" class="styleguide">Running text</h2>
+<p class="styleguide">By default, paragraphs and headings are not styled
 with any bottom spacing. Links are not blue by default,
 as the most common case on Meetup will be block-level
-anchors with large touch targets.</p>
-
-<p>However, there will be instaces where you want the blue
+anchors with large touch targets.</p><p class="styleguide">However, there will be instaces where you want the blue
 links and properly spaced paragraphs of running text (ie.
-event descriptions).</p>
-<div class="codeExample"><div class="exampleOutput"><p>The robot is partially dressed in waterproof surgical garb.</p>
+event descriptions).</p><div class="codeExample">
+  <div class="exampleOutput">
+    <p>The robot is partially dressed in waterproof surgical garb.</p>
 <p>"Bruce Springsteen" is a terrible name for a <a href="#">cat</a>.</p>
 
 <hr style="margin: 8px;" /> <!-- lol, hr -->
@@ -248,7 +315,11 @@ event descriptions).</p>
     <p>The robot is partially dressed in waterproof surgical garb.</p>
     <p>"Bruce Springsteen" is a terrible name for a <a href="#">cat</a>.</p>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;p&gt;</span>The robot is partially dressed in waterproof surgical garb.<span class="nt">&lt;/p&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;p&gt;</span>The robot is partially dressed in waterproof surgical garb.<span class="nt">&lt;/p&gt;</span>
 <span class="nt">&lt;p&gt;</span>"Bruce Springsteen" is a terrible name for a <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>cat<span class="nt">&lt;/a&gt;</span>.<span class="nt">&lt;/p&gt;</span>
 
 <span class="nt">&lt;hr</span> <span class="na">style=</span><span class="s">"margin: 8px;"</span> <span class="nt">/&gt;</span> <span class="c">&lt;!-- lol, hr --&gt;</span>
@@ -256,33 +327,84 @@ event descriptions).</p>
 <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"runningText"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;p&gt;</span>The robot is partially dressed in waterproof surgical garb.<span class="nt">&lt;/p&gt;</span>
     <span class="nt">&lt;p&gt;</span>"Bruce Springsteen" is a terrible name for a <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>cat<span class="nt">&lt;/a&gt;</span>.<span class="nt">&lt;/p&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
-<h2 id="secondaryText">Secondary text</h2>
-<div class="codeExample"><div class="exampleOutput"><p class="text--secondary">Secondary text is secondary</p>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--secondary"</span><span class="nt">&gt;</span>Secondary text is secondary<span class="nt">&lt;/p&gt;</span>
-</pre></div></div></div>
-<h2 id="smallText">Small text</h2>
-<div class="codeExample"><div class="exampleOutput"><p class="text--small">Small text is small</p>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--small"</span><span class="nt">&gt;</span>Small text is small<span class="nt">&lt;/p&gt;</span>
-</pre></div></div></div>
-<h2 id="tertiaryText">Tertiary text</h2>
-<div class="codeExample"><div class="exampleOutput"><p class="text--tertiary">Tertiary text is tertiary</p>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--tertiary"</span><span class="nt">&gt;</span>Tertiary text is tertiary<span class="nt">&lt;/p&gt;</span>
-</pre></div></div></div>
-<h2 id="textGraphic">Graphic text</h2>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<p>Useful when using large text in a graphical way.
-Cuts line height to give the glyph spacing similar to that of an image or icon.</p>
-<div class="codeExample"><div class="exampleOutput"><p class="text--graphic">102</p>
+<h3 id="linkColor" class="styleguide">Link color</h3>
+<p class="styleguide">You can always force an anchor to apply a
+linky blue color by applying the <code class="styleguide">.link</code> class.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <p>Let's force this <a class="link" href="#">link</a> to be blue</p>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;p&gt;</span>Let's force this <span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"link"</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>link<span class="nt">&lt;/a&gt;</span> to be blue<span class="nt">&lt;/p&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
+<h2 id="secondaryText" class="styleguide">Secondary text</h2>
+<div class="codeExample">
+  <div class="exampleOutput">
+    <p class="text--secondary">Secondary text is secondary</p>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--secondary"</span><span class="nt">&gt;</span>Secondary text is secondary<span class="nt">&lt;/p&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
+<h2 id="smallText" class="styleguide">Small text</h2>
+<div class="codeExample">
+  <div class="exampleOutput">
+    <p class="text--small">Small text is small</p>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--small"</span><span class="nt">&gt;</span>Small text is small<span class="nt">&lt;/p&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
+<h2 id="tertiaryText" class="styleguide">Tertiary text</h2>
+<div class="codeExample">
+  <div class="exampleOutput">
+    <p class="text--tertiary">Tertiary text is tertiary</p>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--tertiary"</span><span class="nt">&gt;</span>Tertiary text is tertiary<span class="nt">&lt;/p&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
+<h2 id="textGraphic" class="styleguide">Graphic text</h2>
+<p class="styleguide">Useful when using large text in a graphical way.
+Cuts line height to give the glyph spacing similar to that of an image or icon.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <p class="text--graphic">102</p>
 <p>Miles per hour</p>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--graphic"</span><span class="nt">&gt;</span>102<span class="nt">&lt;/p&gt;</span>
-<span class="nt">&lt;p&gt;</span>Miles per hour<span class="nt">&lt;/p&gt;</span>
-</pre></div></div></div>
-<h1 id="headings">Headings</h1>
 
-<p>TK - notes about UI text vs. body text</p>
-<div class="codeExample"><div class="exampleOutput"><h1 class="text--display">Heading 1 Display</h1>
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--graphic"</span><span class="nt">&gt;</span>102<span class="nt">&lt;/p&gt;</span>
+<span class="nt">&lt;p&gt;</span>Miles per hour<span class="nt">&lt;/p&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
+<h1 id="headings" class="styleguide">Headings</h1>
+<p class="styleguide">TK - notes about UI text vs. body text</p><div class="codeExample">
+  <div class="exampleOutput">
+    <h1 class="text--display">Heading 1 Display</h1>
 <h1>Heading 1 (white by default for use in navbar)</h1>
 <h2>Heading 2</h2>
 <h3>Heading 3</h3>
@@ -294,7 +416,11 @@ Cuts line height to give the glyph spacing similar to that of an image or icon.<
 <p class="text--hint">Hint text</p>
 <p class="text--small">Small text</p>
 <p class="text--caption">Caption text</p>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;h1</span> <span class="na">class=</span><span class="s">"text--display"</span><span class="nt">&gt;</span>Heading 1 Display<span class="nt">&lt;/h1&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;h1</span> <span class="na">class=</span><span class="s">"text--display"</span><span class="nt">&gt;</span>Heading 1 Display<span class="nt">&lt;/h1&gt;</span>
 <span class="nt">&lt;h1&gt;</span>Heading 1 (white by default for use in navbar)<span class="nt">&lt;/h1&gt;</span>
 <span class="nt">&lt;h2&gt;</span>Heading 2<span class="nt">&lt;/h2&gt;</span>
 <span class="nt">&lt;h3&gt;</span>Heading 3<span class="nt">&lt;/h3&gt;</span>
@@ -305,20 +431,37 @@ Cuts line height to give the glyph spacing similar to that of an image or icon.<
 <span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--heading"</span><span class="nt">&gt;</span>Fake heading<span class="nt">&lt;/p&gt;</span>
 <span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--hint"</span><span class="nt">&gt;</span>Hint text<span class="nt">&lt;/p&gt;</span>
 <span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--small"</span><span class="nt">&gt;</span>Small text<span class="nt">&lt;/p&gt;</span>
-<span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--caption"</span><span class="nt">&gt;</span>Caption text<span class="nt">&lt;/p&gt;</span>
-</pre></div></div></div>
-<h2 id="displayText">Display text</h2>
+<span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"text--caption"</span><span class="nt">&gt;</span>Caption text<span class="nt">&lt;/p&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<p>Display text for header hero elements.</p>
-<div class="codeExample"><div class="exampleOutput"><h1 class="text--display">The hero gotham deserves</h1>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;h1</span> <span class="na">class=</span><span class="s">"text--display"</span><span class="nt">&gt;</span>The hero gotham deserves<span class="nt">&lt;/h1&gt;</span>
-</pre></div></div></div>
-<h2 id="headlineText">Headline text</h2>
+<h2 id="displayText" class="styleguide">Display text</h2>
+<p class="styleguide">Display text for header hero elements.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <h1 class="text--display">The hero gotham deserves</h1>
 
-<p>Headline text for when something between display and normal text is needed. Use sparingly and with caution.</p>
-<div class="codeExample"><div class="exampleOutput"><h2 class="text--headline">If display text is Batman, I'm Robin</h2>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;h2</span> <span class="na">class=</span><span class="s">"text--headline"</span><span class="nt">&gt;</span>If display text is Batman, I'm Robin<span class="nt">&lt;/h2&gt;</span>
-</pre></div></div></div>	</main>
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;h1</span> <span class="na">class=</span><span class="s">"text--display"</span><span class="nt">&gt;</span>The hero gotham deserves<span class="nt">&lt;/h1&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
+<h2 id="headlineText" class="styleguide">Headline text</h2>
+<p class="styleguide">Headline text for when something between display and normal text is needed. Use sparingly and with caution.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <h2 class="text--headline">If display text is Batman, I'm Robin</h2>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;h2</span> <span class="na">class=</span><span class="s">"text--headline"</span><span class="nt">&gt;</span>If display text is Batman, I'm Robin<span class="nt">&lt;/h2&gt;</span></pre>
+    </div>
+  </div>
+</div>
+	</main>
 	</section>
 
 <!-- lunr.js search index -->
@@ -605,16 +748,6 @@ $(function() {
 				
 
 				index.add({
-					"title": "Link color",
-					"breadcrumb": "Sass Utils | Mixins & Placeholders > Link color",
-					"path": "sass_utils_|_mixins_&_placeholders.html#linkColor"
-				});
-
-			
-				
-				
-
-				index.add({
 					"title": "Text protection shim",
 					"breadcrumb": "Sass Utils | Mixins & Placeholders > Text protection shim",
 					"path": "sass_utils_|_mixins_&_placeholders.html#textProtection"
@@ -689,8 +822,8 @@ $(function() {
 				
 
 				index.add({
-					"title": "Anchors & Buttons",
-					"breadcrumb": "Modifier Classes > Anchors & Buttons",
+					"title": "Anchors &amp; Buttons",
+					"breadcrumb": "Modifier Classes > Anchors &amp; Buttons",
 					"path": "modifier_classes.html#buttonMod"
 				});
 
@@ -1020,6 +1153,16 @@ $(function() {
 					"title": "Running text",
 					"breadcrumb": "Typography > Running text",
 					"path": "typography.html#runningText"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Link color",
+					"breadcrumb": "Typography > Link color",
+					"path": "typography.html#linkColor"
 				});
 
 			

--- a/docs/build/typography.html
+++ b/docs/build/typography.html
@@ -492,6 +492,13 @@ $(function() {
 		});
 	}
 
+
+	// TODO: modal code
+
+
+
+
+
 	//
 	// lunr search index
 	//
@@ -691,6 +698,36 @@ $(function() {
 					"title": "Clearfix placeholder",
 					"breadcrumb": "Sass Utils | Mixins & Placeholders > Clearfix placeholder",
 					"path": "sass_utils_|_mixins_&_placeholders.html#clearfix"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal mixins",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal mixins",
+					"path": "sass_utils_|_mixins_&_placeholders.html#modalUtils"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal Dialog Mixin",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal Dialog Mixin",
+					"path": "sass_utils_|_mixins_&_placeholders.html#Modal_Dialog_Mixin"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal Full Mixin",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal Full Mixin",
+					"path": "sass_utils_|_mixins_&_placeholders.html#Modal_Full_Mixin"
 				});
 
 			
@@ -1511,6 +1548,36 @@ $(function() {
 		
 	
 		
+			
+				
+				
+
+				index.add({
+					"title": "Modals",
+					"breadcrumb": "Views > Modals",
+					"path": "views.html#modals"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Full Modal View",
+					"breadcrumb": "Views > Full Modal View",
+					"path": "views.html#fullModalView"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Snap Modal View (Dialog)",
+					"breadcrumb": "Views > Snap Modal View (Dialog)",
+					"path": "views.html#snapModalView"
+				});
+
 			
 				
 				

--- a/docs/build/typography.html
+++ b/docs/build/typography.html
@@ -472,9 +472,11 @@ $(function() {
 	//
 	// Disable links by default
 	//
-	$('a').click(function(e) {
-		if ( $(this).hasClass('followLink') ) return;
-		e.preventDefault();
+	$('a').on("click", function(e) {
+		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+			e.preventDefault();
+		}
+		return;
 	});
 
 	//

--- a/docs/build/ui_components.html
+++ b/docs/build/ui_components.html
@@ -183,20 +183,16 @@
 		</nav>
 
 	 	<main id="content" class="stack-item">
-<h1 id="attachment">Attachment</h1>
-
-<p>Adding the <code>attachment</code> class to an elemeent
-creates a context in which layout classes (<code>row-item</code>,
-<code>chunk</code>, <code>list</code>) use half of their default spacing.</p>
-
-<p>In foundation, an &quot;attachment&quot; is a piece of
+<h1 id="attachment" class="styleguide">Attachment</h1>
+<p class="styleguide">Adding the <code class="styleguide">attachment</code> class to an elemeent
+creates a context in which layout classes (<code class="styleguide">row-item</code>,
+<code class="styleguide">chunk</code>, <code class="styleguide">list</code>) use half of their default spacing.</p><p class="styleguide">In foundation, an &quot;attachment&quot; is a piece of
 content in the feed attached to a parent item
-(ie. a reply or event meta info).</p>
-
-<p><em>Ancestry only affects spacing in <code>attachment</code>. Text sizing remains explicit.</em></p>
-
+(ie. a reply or event meta info).</p><p class="styleguide"><em>Ancestry only affects spacing in <code class="styleguide">attachment</code>. Text sizing remains explicit.</em></p>
 <h3>Event meta info example</h3>
-<div class="codeExample"><div class="exampleOutput"><div class="row attachment chunk">
+<div class="codeExample">
+  <div class="exampleOutput">
+    <div class="row attachment chunk">
     <div class="row-item row-item--shrink">
         <time class="tearsheet" datetime="2017-01-13">13</time>
     </div>
@@ -214,7 +210,11 @@ content in the feed attached to a parent item
         <h4>Backpacking For Beginners</h4>
     </div>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row attachment chunk"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row attachment chunk"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row-item row-item--shrink"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;time</span> <span class="na">class=</span><span class="s">"tearsheet"</span> <span class="na">datetime=</span><span class="s">"2017-01-13"</span><span class="nt">&gt;</span>13<span class="nt">&lt;/time&gt;</span>
     <span class="nt">&lt;/div&gt;</span>
@@ -231,10 +231,15 @@ content in the feed attached to a parent item
         <span class="nt">&lt;h4</span> <span class="na">class=</span><span class="s">"text--caption"</span><span class="nt">&gt;</span>Monday Jan 13, 6:30 pm<span class="nt">&lt;/h4&gt;</span>
         <span class="nt">&lt;h4&gt;</span>Backpacking For Beginners<span class="nt">&lt;/h4&gt;</span>
     <span class="nt">&lt;/div&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
 <h3>Discussion reply example</h3>
-<div class="codeExample"><div class="exampleOutput"><div class="row attachment chunk">
+<div class="codeExample">
+  <div class="exampleOutput">
+    <div class="row attachment chunk">
     <div class="row-item row-item--shrink">
         <a href="#" class="avatar avatar--person avatar--small" style="background-image: url(http://photos3.meetupstatic.com/photos/member/9/1/8/4/thumb_141217252.jpeg);"></a>
     </div>
@@ -243,7 +248,11 @@ content in the feed attached to a parent item
         <p class="display--inline">This is a reply to a post. I'm going to keep writing until the line wraps. Has it wrapped yet? Who cares.</p>
     </div>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row attachment chunk"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row attachment chunk"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row-item row-item--shrink"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span> <span class="na">class=</span><span class="s">"avatar avatar--person avatar--small"</span> <span class="na">style=</span><span class="s">"background-image: url(http://photos3.meetupstatic.com/photos/member/9/1/8/4/thumb_141217252.jpeg);"</span><span class="nt">&gt;&lt;/a&gt;</span>
     <span class="nt">&lt;/div&gt;</span>
@@ -251,10 +260,15 @@ content in the feed attached to a parent item
         <span class="nt">&lt;h4</span> <span class="na">class=</span><span class="s">"text--bold display--inline"</span><span class="nt">&gt;</span>Member Name<span class="nt">&lt;/h4&gt;</span>
         <span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"display--inline"</span><span class="nt">&gt;</span>This is a reply to a post. I'm going to keep writing until the line wraps. Has it wrapped yet? Who cares.<span class="nt">&lt;/p&gt;</span>
     <span class="nt">&lt;/div&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
-<h1 id="avatar">Avatar</h1>
-<div class="codeExample"><div class="exampleOutput"><ul class="inlineblockList">
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
+<h1 id="avatar" class="styleguide">Avatar</h1>
+<div class="codeExample">
+  <div class="exampleOutput">
+    <ul class="inlineblockList">
     <li>
         <a href="#" class="avatar avatar--person" style="background-image: url(http://photos3.meetupstatic.com/photos/member/9/1/8/4/thumb_141217252.jpeg);">Member Name</a>
     </li>
@@ -283,7 +297,11 @@ content in the feed attached to a parent item
         </a>
     </li>
 </ul>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;ul</span> <span class="na">class=</span><span class="s">"inlineblockList"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;ul</span> <span class="na">class=</span><span class="s">"inlineblockList"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;li&gt;</span>
         <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span> <span class="na">class=</span><span class="s">"avatar avatar--person"</span> <span class="na">style=</span><span class="s">"background-image: url(http://photos3.meetupstatic.com/photos/member/9/1/8/4/thumb_141217252.jpeg);"</span><span class="nt">&gt;</span>Member Name<span class="nt">&lt;/a&gt;</span>
     <span class="nt">&lt;/li&gt;</span>
@@ -311,49 +329,48 @@ content in the feed attached to a parent item
             <span class="nt">&lt;abbr</span> <span class="na">title=</span><span class="s">"Jake Levine"</span> <span class="na">class=</span><span class="s">"avatar-initial"</span><span class="nt">&gt;</span>J<span class="nt">&lt;/abbr&gt;</span>
         <span class="nt">&lt;/a&gt;</span>
     <span class="nt">&lt;/li&gt;</span>
-<span class="nt">&lt;/ul&gt;</span>
-</pre></div></div></div>
+<span class="nt">&lt;/ul&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
 <h2>Avatar variants</h2>
-
-<p>A base class of <code>avatar</code> is <strong>required</strong>. The following classes are
-optional variants:</p>
-
-<table><thead>
-<tr>
+<p class="styleguide">A base class of <code class="styleguide">avatar</code> is <strong>required</strong>. The following classes are
+optional variants:</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>avatar--small</code></td>
+ <tr>
+<td><code class="styleguide">avatar--small</code></td>
 <td>Adjusts avatar size to the smallest media size</td>
 </tr>
 <tr>
-<td><code>avatar--big</code></td>
+<td><code class="styleguide">avatar--big</code></td>
 <td>Adjusts avatar size to the biggest media size</td>
 </tr>
 <tr>
-<td><code>avatar--person</code></td>
+<td><code class="styleguide">avatar--person</code></td>
 <td>Variant for people</td>
 </tr>
 <tr>
-<td><code>avatar--org</code></td>
+<td><code class="styleguide">avatar--org</code></td>
 <td>Variant for organizers</td>
 </tr>
 <tr>
-<td><code>avatar--fbFriend</code></td>
+<td><code class="styleguide">avatar--fbFriend</code></td>
 <td>Variant for facebook friends</td>
 </tr>
 <tr>
-<td><code>avatar--icon</code></td>
+<td><code class="styleguide">avatar--icon</code></td>
 <td>For icons in avatars (might move this in a later version)</td>
 </tr>
-</tbody></table>
-
-<h1 id="buttons">Buttons</h1>
+ </table>
+<h1 id="buttons" class="styleguide">Buttons</h1>
 
 <h4>Example</h4>
-<div class="codeExample"><div class="exampleOutput"><a class="button" href="#">Button</a>
+<div class="codeExample">
+  <div class="exampleOutput">
+    <a class="button" href="#">Button</a>
 <a class="button button--primary" href="#">Primary Button</a>
 <a class="button" href="#">
     <span class="button-label">Button with Icon</span>
@@ -366,7 +383,11 @@ optional variants:</p>
 <a class="button button--primary button--contrast" href="#">Contrast Button</a>
 <a class="button button--small" href="#">Small Button</a>
 <a class="button button--bordered button--fullWidth" href="#">Full width button</a>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"button"</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>Button<span class="nt">&lt;/a&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"button"</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>Button<span class="nt">&lt;/a&gt;</span>
 <span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"button button--primary"</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>Primary Button<span class="nt">&lt;/a&gt;</span>
 <span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"button"</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"button-label"</span><span class="nt">&gt;</span>Button with Icon<span class="nt">&lt;/span&gt;</span>
@@ -378,44 +399,39 @@ optional variants:</p>
 <span class="nt">&lt;br</span> <span class="nt">/&gt;</span>
 <span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"button button--primary button--contrast"</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>Contrast Button<span class="nt">&lt;/a&gt;</span>
 <span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"button button--small"</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>Small Button<span class="nt">&lt;/a&gt;</span>
-<span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"button button--bordered button--fullWidth"</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>Full width button<span class="nt">&lt;/a&gt;</span>
-</pre></div></div></div>
+<span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"button button--bordered button--fullWidth"</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>Full width button<span class="nt">&lt;/a&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
 <h4>Button variants</h4>
-
-<p>A class of <code>.button</code> is <strong>required</strong> for buttons. The following
-classes are optional variants:</p>
-
-<table><thead>
-<tr>
+<p class="styleguide">A class of <code class="styleguide">.button</code> is <strong>required</strong> for buttons. The following
+classes are optional variants:</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.button--primary</code></td>
+ <tr>
+<td><code class="styleguide">.button--primary</code></td>
 <td>rounded button with dark background; for primary actions</td>
 </tr>
 <tr>
-<td><code>.button--contrast</code></td>
+<td><code class="styleguide">.button--contrast</code></td>
 <td>bold, dark text; use on dark backgrounds or photos (ie. top nav bar)</td>
 </tr>
 <tr>
-<td><code>.button--bordered</code></td>
+<td><code class="styleguide">.button--bordered</code></td>
 <td>rounded bordered button</td>
 </tr>
 <tr>
-<td><code>.button--small</code></td>
+<td><code class="styleguide">.button--small</code></td>
 <td>decreases size of button</td>
 </tr>
-</tbody></table>
-
-<h1 id="collapsible">Collapsible</h1>
-
-<p>Collapses elements using class toggling. A base
-class of <code>collapsible</code> is <strong>required</strong>.</p>
-
-<p>To collapse the element, add the <code>collapsible--close</code> class.</p>
-<div class="codeExample"><div class="exampleOutput"><a id="cTrigger" class="button button--primary chunk followLink">Toggle</a>
+ </table>
+<h1 id="collapsible" class="styleguide">Collapsible</h1>
+<p class="styleguide">Collapses elements using class toggling. A base
+class of <code class="styleguide">collapsible</code> is <strong>required</strong>.</p><p class="styleguide">To collapse the element, add the <code class="styleguide">collapsible--close</code> class.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <a id="cTrigger" class="button button--primary chunk followLink">Toggle</a>
 
 <section class="stripe collapsible" id="cContainer">
     <div class="bounds collapsible-content">
@@ -423,48 +439,56 @@ class of <code>collapsible</code> is <strong>required</strong>.</p>
         <p>Adding a class of `collapsible--close` to this `section` will set max height to 0vh</p>
     </div>
 </section>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;a</span> <span class="na">id=</span><span class="s">"cTrigger"</span> <span class="na">class=</span><span class="s">"button button--primary chunk followLink"</span><span class="nt">&gt;</span>Toggle<span class="nt">&lt;/a&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;a</span> <span class="na">id=</span><span class="s">"cTrigger"</span> <span class="na">class=</span><span class="s">"button button--primary chunk followLink"</span><span class="nt">&gt;</span>Toggle<span class="nt">&lt;/a&gt;</span>
 
 <span class="nt">&lt;section</span> <span class="na">class=</span><span class="s">"stripe collapsible"</span> <span class="na">id=</span><span class="s">"cContainer"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"bounds collapsible-content"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;h2&gt;</span>I'm collapsible content<span class="nt">&lt;/h2&gt;</span>
         <span class="nt">&lt;p&gt;</span>Adding a class of `collapsible--close` to this `section` will set max height to 0vh<span class="nt">&lt;/p&gt;</span>
     <span class="nt">&lt;/div&gt;</span>
-<span class="nt">&lt;/section&gt;</span>
-</pre></div></div></div>
-<h1 id="floatingAction">Floating Action</h1>
+<span class="nt">&lt;/section&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<p>If a page has a single important action, you can use a <code>floatingAction</code> wrapper to
-call it out. At small screen sizes, the element with the <code>floatingAction</code> class
-will fix to the bottom of the viewport.</p>
-
-<p><strong>Note:</strong> A class of <code>hasFloatingAction</code> is available if extra space is needed at the bottom
-of a page for the floating action to &quot;land&quot; in. Apply to the <code>body</code> tag.</p>
-<div class="codeExample"><div class="exampleOutput">    <div class="bounds">
+<h1 id="floatingAction" class="styleguide">Floating Action</h1>
+<p class="styleguide">If a page has a single important action, you can use a <code class="styleguide">floatingAction</code> wrapper to
+call it out. At small screen sizes, the element with the <code class="styleguide">floatingAction</code> class
+will fix to the bottom of the viewport.</p><p class="styleguide"><strong>Note:</strong> A class of <code class="styleguide">hasFloatingAction</code> is available if extra space is needed at the bottom
+of a page for the floating action to &quot;land&quot; in. Apply to the <code class="styleguide">body</code> tag.</p><div class="codeExample">
+  <div class="exampleOutput">
+        <div class="bounds">
         <p class="chunk">The button below will fix to the bottom of the viewport at small sizes</p>
         <div class="floatingAction">
             <a href="#" class="chunk button button--primary button--fullWidth">Floating Action</a>
         </div>
     </div>
-</div><div class="codeBlock"><div class="highlight"><pre>    <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"bounds"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"bounds"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"chunk"</span><span class="nt">&gt;</span>The button below will fix to the bottom of the viewport at small sizes<span class="nt">&lt;/p&gt;</span>
         <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"floatingAction"</span><span class="nt">&gt;</span>
             <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span> <span class="na">class=</span><span class="s">"chunk button button--primary button--fullWidth"</span><span class="nt">&gt;</span>Floating Action<span class="nt">&lt;/a&gt;</span>
         <span class="nt">&lt;/div&gt;</span>
-    <span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
-<h1 id="menu">Menu</h1>
+    <span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<p>Context menu style dropdoowns. Actions are delivered in-document
+<h1 id="menu" class="styleguide">Menu</h1>
+<p class="styleguide">Context menu style dropdoowns. Actions are delivered in-document
 next to the menu toggle as a non-js fallback. When a client is
-javascript-enabled, the menu is hidden and posisitioned absolute.</p>
-
-<p>Toggling of menu visibility is handled with javascript (supporting js
-for documentation TK).</p>
-
-<p><strong>NOTE:</strong> This visual example currently shows the non-js fallback only.
-Use as a guide for markup.</p>
-<div class="codeExample"><div class="exampleOutput"><div class="menu">
+javascript-enabled, the menu is hidden and posisitioned absolute.</p><p class="styleguide">Toggling of menu visibility is handled with javascript (supporting js
+for documentation TK).</p><p class="styleguide"><strong>NOTE:</strong> This visual example currently shows the non-js fallback only.
+Use as a guide for markup.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <div class="menu">
     <a class="menu-toggle" href="#">(icon)</a>
 
     <ul class="menu-actions">
@@ -476,7 +500,11 @@ Use as a guide for markup.</p>
         </li>
     </ul>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"menu"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"menu"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"menu-toggle"</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>(icon)<span class="nt">&lt;/a&gt;</span>
 
     <span class="nt">&lt;ul</span> <span class="na">class=</span><span class="s">"menu-actions"</span><span class="nt">&gt;</span>
@@ -487,143 +515,174 @@ Use as a guide for markup.</p>
             <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>Select None<span class="nt">&lt;/a&gt;</span>
         <span class="nt">&lt;/li&gt;</span>
     <span class="nt">&lt;/ul&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
-<h1 id="tabs">Tabs</h1>
-<div class="codeExample"><div class="exampleOutput"><nav>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
+<h1 id="tabs" class="styleguide">Tabs</h1>
+<div class="codeExample">
+  <div class="exampleOutput">
+    <nav>
     <ul class="tabs">
         <li class="tabs-tab"><a href="#">Tab One</a></li>
         <li class="tabs-tab tabs-tab--selected"><a href="#">Tab Two</a></li>
         <li class="tabs-tab"><a href="#">Tab Three</a></li>
     </ul>
 </nav>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;nav&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;nav&gt;</span>
     <span class="nt">&lt;ul</span> <span class="na">class=</span><span class="s">"tabs"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"tabs-tab"</span><span class="nt">&gt;&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>Tab One<span class="nt">&lt;/a&gt;&lt;/li&gt;</span>
         <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"tabs-tab tabs-tab--selected"</span><span class="nt">&gt;&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>Tab Two<span class="nt">&lt;/a&gt;&lt;/li&gt;</span>
         <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"tabs-tab"</span><span class="nt">&gt;&lt;a</span> <span class="na">href=</span><span class="s">"#"</span><span class="nt">&gt;</span>Tab Three<span class="nt">&lt;/a&gt;&lt;/li&gt;</span>
     <span class="nt">&lt;/ul&gt;</span>
-<span class="nt">&lt;/nav&gt;</span>
-</pre></div></div></div>
+<span class="nt">&lt;/nav&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
 <h3>Tabs (parent) variants</h3>
-
-<p>A class of <code>tabs</code> is <strong>required</strong>. The following classes are
-optional variants:</p>
-
-<table><thead>
-<tr>
+<p class="styleguide">A class of <code class="styleguide">tabs</code> is <strong>required</strong>. The following classes are
+optional variants:</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>tabs--full</code></td>
+ <tr>
+<td><code class="styleguide">tabs--full</code></td>
 <td>Makes tabs span the full width of their parent element</td>
 </tr>
-</tbody></table>
-
+ </table>
 <h3>Tab (child) variants</h3>
-
-<p>A class of <code>tabs-tab</code> is <strong>required</strong> for tabs. The following classes
-are optional variants:</p>
-
-<table><thead>
-<tr>
+<p class="styleguide">A class of <code class="styleguide">tabs-tab</code> is <strong>required</strong> for tabs. The following classes
+are optional variants:</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>tabs-tab--selected</code></td>
+ <tr>
+<td><code class="styleguide">tabs-tab--selected</code></td>
 <td>Applies styles for tab selected state</td>
 </tr>
-</tbody></table>
-
-<h1 id="tag">RSVP Tags</h1>
-
-<p>Status tags for RSVP.</p>
-<div class="codeExample"><div class="exampleOutput"><div class="rsvpTag rsvpTag--yes">Going</div>
+ </table>
+<h1 id="tag" class="styleguide">RSVP Tags</h1>
+<p class="styleguide">Status tags for RSVP.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <div class="rsvpTag rsvpTag--yes">Going</div>
 <div class="rsvpTag rsvpTag--no">Not going</div>
 <div class="rsvpTag rsvpTag--waiting">Waiting</div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"rsvpTag rsvpTag--yes"</span><span class="nt">&gt;</span>Going<span class="nt">&lt;/div&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"rsvpTag rsvpTag--yes"</span><span class="nt">&gt;</span>Going<span class="nt">&lt;/div&gt;</span>
 <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"rsvpTag rsvpTag--no"</span><span class="nt">&gt;</span>Not going<span class="nt">&lt;/div&gt;</span>
-<span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"rsvpTag rsvpTag--waiting"</span><span class="nt">&gt;</span>Waiting<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
+<span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"rsvpTag rsvpTag--waiting"</span><span class="nt">&gt;</span>Waiting<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
 <h2>Variants</h2>
-
-<p>A class of <code>rsvpTag</code> is <strong>required</strong>.
-Variant classes:</p>
-
-<table><thead>
-<tr>
+<p class="styleguide">A class of <code class="styleguide">rsvpTag</code> is <strong>required</strong>.
+Variant classes:</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>rsvpTag--yes</code></td>
+ <tr>
+<td><code class="styleguide">rsvpTag--yes</code></td>
 <td>indicates &quot;yes&quot; RSVP status</td>
 </tr>
 <tr>
-<td><code>rsvpTag--no</code></td>
+<td><code class="styleguide">rsvpTag--no</code></td>
 <td>indicates &quot;no&quot; RSVP status</td>
 </tr>
 <tr>
-<td><code>rsvpTag--waiting</code></td>
+<td><code class="styleguide">rsvpTag--waiting</code></td>
 <td>indicates waitlist RSVP status</td>
 </tr>
-</tbody></table>
-
-<h1 id="tearsheet">Tearsheet</h1>
-
-<p>Standard display for dates.</p>
-
+ </table>
+<h1 id="tearsheet" class="styleguide">Tearsheet</h1>
+<p class="styleguide">Standard display for dates.</p>
 <h4>Tearsheet example</h4>
-<div class="codeExample"><div class="exampleOutput"><div class="tearsheet">13</div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"tearsheet"</span><span class="nt">&gt;</span>13<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
+<div class="codeExample">
+  <div class="exampleOutput">
+    <div class="tearsheet">13</div>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"tearsheet"</span><span class="nt">&gt;</span>13<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
 <h4>Tearsheet with date detail</h4>
-<div class="codeExample"><div class="exampleOutput"><div class="dateTime">
+<div class="codeExample">
+  <div class="exampleOutput">
+    <div class="dateTime">
     <div class="dateTime-tearsheet">13</div>
     <p class="dateTime-detail">Tomorrow at 7:00 PM</p>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"dateTime"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"dateTime"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"dateTime-tearsheet"</span><span class="nt">&gt;</span>13<span class="nt">&lt;/div&gt;</span>
     <span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">"dateTime-detail"</span><span class="nt">&gt;</span>Tomorrow at 7:00 PM<span class="nt">&lt;/p&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
-<h1 id="togglePills">Toggle Pills</h1>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<p>Checkbox form elements styled as toggle buttons.</p>
-
+<h1 id="togglePills" class="styleguide">Toggle Pills</h1>
+<p class="styleguide">Checkbox form elements styled as toggle buttons.</p>
 <h2>&quot;unchecked&quot; state</h2>
-<div class="codeExample"><div class="exampleOutput"><div class="toggleButton">
+<div class="codeExample">
+  <div class="exampleOutput">
+    <div class="toggleButton">
     <input class="toggleButton-input" type="checkbox" name="topic-dining" id="topic-dining" value="ToggleBtn" />
     <label class="toggleButton-label" for="topic-dining">Dining Out</label>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"toggleButton"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"toggleButton"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;input</span> <span class="na">class=</span><span class="s">"toggleButton-input"</span> <span class="na">type=</span><span class="s">"checkbox"</span> <span class="na">name=</span><span class="s">"topic-dining"</span> <span class="na">id=</span><span class="s">"topic-dining"</span> <span class="na">value=</span><span class="s">"ToggleBtn"</span> <span class="nt">/&gt;</span>
     <span class="nt">&lt;label</span> <span class="na">class=</span><span class="s">"toggleButton-label"</span> <span class="na">for=</span><span class="s">"topic-dining"</span><span class="nt">&gt;</span>Dining Out<span class="nt">&lt;/label&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
 <h2>&quot;checked&quot; state</h2>
-<div class="codeExample"><div class="exampleOutput"><div class="toggleButton">
+<div class="codeExample">
+  <div class="exampleOutput">
+    <div class="toggleButton">
     <input checked class="toggleButton-input" type="checkbox" name="topic-hiking" id="topic-hiking" value="ToggleBtn" />
     <label class="toggleButton-label" for="topic-hiking">Hiking</label>
 </div>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"toggleButton"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"toggleButton"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;input</span> <span class="na">checked</span> <span class="na">class=</span><span class="s">"toggleButton-input"</span> <span class="na">type=</span><span class="s">"checkbox"</span> <span class="na">name=</span><span class="s">"topic-hiking"</span> <span class="na">id=</span><span class="s">"topic-hiking"</span> <span class="na">value=</span><span class="s">"ToggleBtn"</span> <span class="nt">/&gt;</span>
     <span class="nt">&lt;label</span> <span class="na">class=</span><span class="s">"toggleButton-label"</span> <span class="na">for=</span><span class="s">"topic-hiking"</span><span class="nt">&gt;</span>Hiking<span class="nt">&lt;/label&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
-</pre></div></div></div>
-<h1 id="uiCard">Cards</h1>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
+  </div>
+</div>
 
-<p>Card-like boxes.</p>
-
+<h1 id="uiCard" class="styleguide">Cards</h1>
+<p class="styleguide">Card-like boxes.</p>
 <h2>Standard, Group, and Event cards</h2>
-
-<p>(This example uses <code>gridList</code>, but cards may placed anywhere)</p>
-<div class="codeExample"><div class="exampleOutput"><section class="stripe--collection">
+<p class="styleguide">(This example uses <code class="styleguide">gridList</code>, but cards may placed anywhere)</p><div class="codeExample">
+  <div class="exampleOutput">
+    <section class="stripe--collection">
     <div class="bounds">
         <ul class="gridList gridList--has1 atMedium_gridList--has3">
 
@@ -651,7 +710,11 @@ Variant classes:</p>
         </ul>
     </div>
 </section>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;section</span> <span class="na">class=</span><span class="s">"stripe--collection"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;section</span> <span class="na">class=</span><span class="s">"stripe--collection"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"bounds"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;ul</span> <span class="na">class=</span><span class="s">"gridList gridList--has1 atMedium_gridList--has3"</span><span class="nt">&gt;</span>
 
@@ -678,15 +741,16 @@ Variant classes:</p>
             <span class="nt">&lt;/li&gt;</span>
         <span class="nt">&lt;/ul&gt;</span>
     <span class="nt">&lt;/div&gt;</span>
-<span class="nt">&lt;/section&gt;</span>
-</pre></div></div></div>
+<span class="nt">&lt;/section&gt;</span></pre>
+    </div>
+  </div>
+</div>
+
 <h3>Event card detail</h3>
-
-<p>An example of a full event card recipie using
-<code>.card</code> with other existing Sassquatch2 components.</p>
-
-<p><em>(The inline style on the card element is for documentation purposes only)</em></p>
-<div class="codeExample"><div class="exampleOutput"><section class="stripe--collection">
+<p class="styleguide">An example of a full event card recipie using
+<code class="styleguide">.card</code> with other existing Sassquatch2 components.</p><p class="styleguide"><em>(The inline style on the card element is for documentation purposes only)</em></p><div class="codeExample">
+  <div class="exampleOutput">
+    <section class="stripe--collection">
     <a href="#" class="chunk card card--event" style="margin: 16px; max-width: 250px;">
 
         <div class="row row--spaceBetween row--wrap">
@@ -812,7 +876,11 @@ Variant classes:</p>
         </div>
     </a>
 </section>
-</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;section</span> <span class="na">class=</span><span class="s">"stripe--collection"</span><span class="nt">&gt;</span>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;section</span> <span class="na">class=</span><span class="s">"stripe--collection"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span> <span class="na">class=</span><span class="s">"chunk card card--event"</span> <span class="na">style=</span><span class="s">"margin: 16px; max-width: 250px;"</span><span class="nt">&gt;</span>
 
         <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row row--spaceBetween row--wrap"</span><span class="nt">&gt;</span>
@@ -937,8 +1005,11 @@ Variant classes:</p>
             <span class="nt">&lt;/ul&gt;</span>
         <span class="nt">&lt;/div&gt;</span>
     <span class="nt">&lt;/a&gt;</span>
-<span class="nt">&lt;/section&gt;</span>
-</pre></div></div></div>	</main>
+<span class="nt">&lt;/section&gt;</span></pre>
+    </div>
+  </div>
+</div>
+	</main>
 	</section>
 
 <!-- lunr.js search index -->
@@ -1225,16 +1296,6 @@ $(function() {
 				
 
 				index.add({
-					"title": "Link color",
-					"breadcrumb": "Sass Utils | Mixins & Placeholders > Link color",
-					"path": "sass_utils_|_mixins_&_placeholders.html#linkColor"
-				});
-
-			
-				
-				
-
-				index.add({
 					"title": "Text protection shim",
 					"breadcrumb": "Sass Utils | Mixins & Placeholders > Text protection shim",
 					"path": "sass_utils_|_mixins_&_placeholders.html#textProtection"
@@ -1309,8 +1370,8 @@ $(function() {
 				
 
 				index.add({
-					"title": "Anchors & Buttons",
-					"breadcrumb": "Modifier Classes > Anchors & Buttons",
+					"title": "Anchors &amp; Buttons",
+					"breadcrumb": "Modifier Classes > Anchors &amp; Buttons",
 					"path": "modifier_classes.html#buttonMod"
 				});
 
@@ -1640,6 +1701,16 @@ $(function() {
 					"title": "Running text",
 					"breadcrumb": "Typography > Running text",
 					"path": "typography.html#runningText"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Link color",
+					"breadcrumb": "Typography > Link color",
+					"path": "typography.html#linkColor"
 				});
 
 			

--- a/docs/build/ui_components.html
+++ b/docs/build/ui_components.html
@@ -1040,6 +1040,13 @@ $(function() {
 		});
 	}
 
+
+	// TODO: modal code
+
+
+
+
+
 	//
 	// lunr search index
 	//
@@ -1239,6 +1246,36 @@ $(function() {
 					"title": "Clearfix placeholder",
 					"breadcrumb": "Sass Utils | Mixins & Placeholders > Clearfix placeholder",
 					"path": "sass_utils_|_mixins_&_placeholders.html#clearfix"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal mixins",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal mixins",
+					"path": "sass_utils_|_mixins_&_placeholders.html#modalUtils"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal Dialog Mixin",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal Dialog Mixin",
+					"path": "sass_utils_|_mixins_&_placeholders.html#Modal_Dialog_Mixin"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal Full Mixin",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal Full Mixin",
+					"path": "sass_utils_|_mixins_&_placeholders.html#Modal_Full_Mixin"
 				});
 
 			
@@ -2059,6 +2096,36 @@ $(function() {
 		
 	
 		
+			
+				
+				
+
+				index.add({
+					"title": "Modals",
+					"breadcrumb": "Views > Modals",
+					"path": "views.html#modals"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Full Modal View",
+					"breadcrumb": "Views > Full Modal View",
+					"path": "views.html#fullModalView"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Snap Modal View (Dialog)",
+					"breadcrumb": "Views > Snap Modal View (Dialog)",
+					"path": "views.html#snapModalView"
+				});
+
 			
 				
 				

--- a/docs/build/ui_components.html
+++ b/docs/build/ui_components.html
@@ -1021,7 +1021,8 @@ $(function() {
 	// Disable links by default
 	//
 	$('a').on("click", function(e) {
-		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+		debugger;
+		if ( this.getAttribute("href") == "#" || $(this).hasClass('noFollow') ) {
 			e.preventDefault();
 		}
 		return;
@@ -1041,13 +1042,6 @@ $(function() {
 			}
 		});
 	}
-
-
-	// TODO: modal code
-
-
-
-
 
 	//
 	// lunr search index

--- a/docs/build/ui_components.html
+++ b/docs/build/ui_components.html
@@ -1020,9 +1020,11 @@ $(function() {
 	//
 	// Disable links by default
 	//
-	$('a').click(function(e) {
-		if ( $(this).hasClass('followLink') ) return;
-		e.preventDefault();
+	$('a').on("click", function(e) {
+		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+			e.preventDefault();
+		}
+		return;
 	});
 
 	//

--- a/docs/build/views.html
+++ b/docs/build/views.html
@@ -138,11 +138,11 @@
 <th>Description</th>
 </tr>
  <tr>
-<td><code class="styleguide">.view-modal--full</code></td>
+<td><code class="styleguide">.view--modalFull</code></td>
 <td>Makes a modal that is full screen on all screen sizes</td>
 </tr>
 <tr>
-<td><code class="styleguide">.view-modal--snap</code></td>
+<td><code class="styleguide">.view--modalSnap</code></td>
 <td>Creates a modal that is full screen on small sizes, overlay/dialog on larger screens</td>
 </tr>
  </table>
@@ -151,7 +151,7 @@
   <div class="exampleOutput">
     <a class="link" href="pages/modal-full.html">Demo</a> 
 
-<div class="view view--modal-full display--none">
+<div class="view view--modalFull display--none">
     <header class="view-head">
         <div class="row inverted"> 
             <a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
@@ -176,7 +176,7 @@
     <div class="highlight">
       <pre><span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"link"</span> <span class="na">href=</span><span class="s">"pages/modal-full.html"</span><span class="nt">&gt;</span>Demo<span class="nt">&lt;/a&gt;</span> 
 
-<span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"view view--modal-full display--none"</span><span class="nt">&gt;</span>
+<span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"view view--modalFull display--none"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;header</span> <span class="na">class=</span><span class="s">"view-head"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row inverted"</span><span class="nt">&gt;</span> 
             <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"http://meetup.com/"</span> <span class="na">class=</span><span class="s">"row-item row-item--shrink row-item--alignMiddle"</span><span class="nt">&gt;</span>
@@ -205,7 +205,7 @@ lays out as a dialog on background content on larger screens.</p><div class="cod
   <div class="exampleOutput">
     <a class="link" href="pages/modal-snap.html">Demo</a> 
 
-<div class="view view--modal-snap display--none">
+<div class="view view--modalSnap display--none">
     <header class="view-head">
         <div class="row inverted"> 
             <a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
@@ -232,7 +232,7 @@ lays out as a dialog on background content on larger screens.</p><div class="cod
     <div class="highlight">
       <pre><span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"link"</span> <span class="na">href=</span><span class="s">"pages/modal-snap.html"</span><span class="nt">&gt;</span>Demo<span class="nt">&lt;/a&gt;</span> 
 
-<span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"view view--modal-snap display--none"</span><span class="nt">&gt;</span>
+<span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"view view--modalSnap display--none"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;header</span> <span class="na">class=</span><span class="s">"view-head"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row inverted"</span><span class="nt">&gt;</span> 
             <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"http://meetup.com/"</span> <span class="na">class=</span><span class="s">"row-item row-item--shrink row-item--alignMiddle"</span><span class="nt">&gt;</span>
@@ -367,7 +367,8 @@ $(function() {
 	// Disable links by default
 	//
 	$('a').on("click", function(e) {
-		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+		debugger;
+		if ( this.getAttribute("href") == "#" || $(this).hasClass('noFollow') ) {
 			e.preventDefault();
 		}
 		return;
@@ -387,13 +388,6 @@ $(function() {
 			}
 		});
 	}
-
-
-	// TODO: modal code
-
-
-
-
 
 	//
 	// lunr search index

--- a/docs/build/views.html
+++ b/docs/build/views.html
@@ -80,6 +80,25 @@
 									
 									
 										<li class="display--inline--mediumDown">
+											<a class="followLink" href="#modals">Modals</a>
+										</li>
+									
+
+								
+
+									
+									
+
+								
+
+									
+									
+
+								
+
+									
+									
+										<li class="display--inline--mediumDown">
 											<a class="followLink" href="#view">View</a>
 										</li>
 									
@@ -111,6 +130,59 @@
 		</nav>
 
 	 	<main id="content" class="stack-item">
+<h1 id="modals" class="styleguide">Modals</h1>
+
+<h2 id="fullModalView" class="styleguide">Full Modal View</h2>
+<p class="styleguide">Modal that is presented full screen on all sizes</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>&lt;div class="view view--modal-full"&gt;
+    &lt;header class="view-head"&gt;
+        &lt;div class="row inverted"&gt; 
+            &lt;a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle"&gt;
+                &lt;img src="style/img/logo.svg" width="35" height="24"&gt;&lt;/a&gt;
+            &lt;/a&gt;
+            &lt;div class="row-item row-item--alignMiddle viewHead-heading"&gt;
+                &lt;h1 class="wrap--singleLine--truncate"&gt;This is a header&lt;/h1&gt; 
+            &lt;/div&gt;
+        &lt;/div&gt;
+    &lt;/header&gt;
+    &lt;div id="modal_body" class="view-body"&gt;
+        &lt;div class="stripe"&gt;
+            &lt;div class="bounds"&gt;
+            ... body content here ...
+            &lt;/div&gt;
+        &lt;/div&gt;
+    &lt;/div&gt;
+&lt;/div&gt;</pre>
+  </div>
+</div>
+<h2 id="snapModalView" class="styleguide">Snap Modal View (Dialog)</h2>
+<p class="styleguide">Modal that snaps to the whole viewport and is full screen on small screens,
+lays out as a dialog on background content on larger screens.</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>&lt;div class="view view--modal-snap"&gt;
+    &lt;header class="view-head"&gt;
+        &lt;div class="row inverted"&gt; 
+            &lt;a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle"&gt;
+                Close
+            &lt;/a&gt;
+            &lt;div class="row-item row-item--alignMiddle viewHead-heading"&gt;
+                &lt;h1 class="wrap--singleLine--truncate"&gt;Change your setting&lt;/h1&gt; 
+            &lt;/div&gt;
+        &lt;/div&gt;
+    &lt;/header&gt;
+    &lt;div id="modal_body" class="view-body"&gt;
+        &lt;div class="stripe"&gt;
+            &lt;div class="bounds"&gt;
+            ... body content here ...
+
+            &lt;button&gt;Save&lt;/button&gt;
+            &lt;/div&gt;
+        &lt;/div&gt;
+    &lt;/div&gt;
+&lt;/div&gt;</pre>
+  </div>
+</div>
 <h1 id="view" class="styleguide">View</h1>
 <p class="styleguide">A &quot;view&quot; contains all layout and content for a given screen.
 Typically, a document only has a single view. Split views,
@@ -239,6 +311,13 @@ $(function() {
 			}
 		});
 	}
+
+
+	// TODO: modal code
+
+
+
+
 
 	//
 	// lunr search index
@@ -439,6 +518,36 @@ $(function() {
 					"title": "Clearfix placeholder",
 					"breadcrumb": "Sass Utils | Mixins & Placeholders > Clearfix placeholder",
 					"path": "sass_utils_|_mixins_&_placeholders.html#clearfix"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal mixins",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal mixins",
+					"path": "sass_utils_|_mixins_&_placeholders.html#modalUtils"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal Dialog Mixin",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal Dialog Mixin",
+					"path": "sass_utils_|_mixins_&_placeholders.html#Modal_Dialog_Mixin"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Modal Full Mixin",
+					"breadcrumb": "Sass Utils | Mixins & Placeholders > Modal Full Mixin",
+					"path": "sass_utils_|_mixins_&_placeholders.html#Modal_Full_Mixin"
 				});
 
 			
@@ -1259,6 +1368,36 @@ $(function() {
 		
 	
 		
+			
+				
+				
+
+				index.add({
+					"title": "Modals",
+					"breadcrumb": "Views > Modals",
+					"path": "views.html#modals"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Full Modal View",
+					"breadcrumb": "Views > Full Modal View",
+					"path": "views.html#fullModalView"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Snap Modal View (Dialog)",
+					"breadcrumb": "Views > Snap Modal View (Dialog)",
+					"path": "views.html#snapModalView"
+				});
+
 			
 				
 				

--- a/docs/build/views.html
+++ b/docs/build/views.html
@@ -132,57 +132,131 @@
 	 	<main id="content" class="stack-item">
 <h1 id="modals" class="styleguide">Modals</h1>
 
+<h2>view--modal variants</h2>
+<table class="styleguide"> <tr>
+<th>Class</th>
+<th>Description</th>
+</tr>
+ <tr>
+<td><code class="styleguide">.view-modal--full</code></td>
+<td>Makes a modal that is full screen on all screen sizes</td>
+</tr>
+<tr>
+<td><code class="styleguide">.view-modal--snap</code></td>
+<td>Creates a modal that is full screen on small sizes, overlay/dialog on larger screens</td>
+</tr>
+ </table>
 <h2 id="fullModalView" class="styleguide">Full Modal View</h2>
-<p class="styleguide">Modal that is presented full screen on all sizes</p><div class="codeBlock">
-  <div class="highlight">
-    <pre>&lt;div class="view view--modal-full"&gt;
-    &lt;header class="view-head"&gt;
-        &lt;div class="row inverted"&gt; 
-            &lt;a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle"&gt;
-                &lt;img src="style/img/logo.svg" width="35" height="24"&gt;&lt;/a&gt;
-            &lt;/a&gt;
-            &lt;div class="row-item row-item--alignMiddle viewHead-heading"&gt;
-                &lt;h1 class="wrap--singleLine--truncate"&gt;This is a header&lt;/h1&gt; 
-            &lt;/div&gt;
-        &lt;/div&gt;
-    &lt;/header&gt;
-    &lt;div id="modal_body" class="view-body"&gt;
-        &lt;div class="stripe"&gt;
-            &lt;div class="bounds"&gt;
+<p class="styleguide">Modal that is presented full screen on all sizes</p><div class="codeExample">
+  <div class="exampleOutput">
+    <a class="link" href="pages/modal-full.html">Demo</a> 
+
+<div class="view view--modal-full display--none">
+    <header class="view-head">
+        <div class="row inverted"> 
+            <a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
+                <img src="style/img/logo.svg" width="35" height="24"></a>
+            </a>
+            <div class="row-item row-item--alignMiddle viewHead-heading">
+                <h1 class="wrap--singleLine--truncate">This is a header</h1> 
+            </div>
+        </div>
+    </header>
+    <div id="modal_body" class="view-body">
+        <div class="stripe">
+            <div class="bounds">
             ... body content here ...
-            &lt;/div&gt;
-        &lt;/div&gt;
-    &lt;/div&gt;
-&lt;/div&gt;</pre>
+            </div>
+        </div>
+    </div>
+</div>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"link"</span> <span class="na">href=</span><span class="s">"pages/modal-full.html"</span><span class="nt">&gt;</span>Demo<span class="nt">&lt;/a&gt;</span> 
+
+<span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"view view--modal-full display--none"</span><span class="nt">&gt;</span>
+    <span class="nt">&lt;header</span> <span class="na">class=</span><span class="s">"view-head"</span><span class="nt">&gt;</span>
+        <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row inverted"</span><span class="nt">&gt;</span> 
+            <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"http://meetup.com/"</span> <span class="na">class=</span><span class="s">"row-item row-item--shrink row-item--alignMiddle"</span><span class="nt">&gt;</span>
+                <span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"style/img/logo.svg"</span> <span class="na">width=</span><span class="s">"35"</span> <span class="na">height=</span><span class="s">"24"</span><span class="nt">&gt;&lt;/a&gt;</span>
+            <span class="nt">&lt;/a&gt;</span>
+            <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row-item row-item--alignMiddle viewHead-heading"</span><span class="nt">&gt;</span>
+                <span class="nt">&lt;h1</span> <span class="na">class=</span><span class="s">"wrap--singleLine--truncate"</span><span class="nt">&gt;</span>This is a header<span class="nt">&lt;/h1&gt;</span> 
+            <span class="nt">&lt;/div&gt;</span>
+        <span class="nt">&lt;/div&gt;</span>
+    <span class="nt">&lt;/header&gt;</span>
+    <span class="nt">&lt;div</span> <span class="na">id=</span><span class="s">"modal_body"</span> <span class="na">class=</span><span class="s">"view-body"</span><span class="nt">&gt;</span>
+        <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"stripe"</span><span class="nt">&gt;</span>
+            <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"bounds"</span><span class="nt">&gt;</span>
+            ... body content here ...
+            <span class="nt">&lt;/div&gt;</span>
+        <span class="nt">&lt;/div&gt;</span>
+    <span class="nt">&lt;/div&gt;</span>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
   </div>
 </div>
+
 <h2 id="snapModalView" class="styleguide">Snap Modal View (Dialog)</h2>
 <p class="styleguide">Modal that snaps to the whole viewport and is full screen on small screens,
-lays out as a dialog on background content on larger screens.</p><div class="codeBlock">
-  <div class="highlight">
-    <pre>&lt;div class="view view--modal-snap"&gt;
-    &lt;header class="view-head"&gt;
-        &lt;div class="row inverted"&gt; 
-            &lt;a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle"&gt;
+lays out as a dialog on background content on larger screens.</p><div class="codeExample">
+  <div class="exampleOutput">
+    <a class="link" href="pages/modal-snap.html">Demo</a> 
+
+<div class="view view--modal-snap display--none">
+    <header class="view-head">
+        <div class="row inverted"> 
+            <a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
                 Close
-            &lt;/a&gt;
-            &lt;div class="row-item row-item--alignMiddle viewHead-heading"&gt;
-                &lt;h1 class="wrap--singleLine--truncate"&gt;Change your setting&lt;/h1&gt; 
-            &lt;/div&gt;
-        &lt;/div&gt;
-    &lt;/header&gt;
-    &lt;div id="modal_body" class="view-body"&gt;
-        &lt;div class="stripe"&gt;
-            &lt;div class="bounds"&gt;
+            </a>
+            <div class="row-item row-item--alignMiddle viewHead-heading">
+                <h1 class="wrap--singleLine--truncate">Change your setting</h1> 
+            </div>
+        </div>
+    </header>
+    <div id="modal_body" class="view-body">
+        <div class="stripe">
+            <div class="bounds">
             ... body content here ...
 
-            &lt;button&gt;Save&lt;/button&gt;
-            &lt;/div&gt;
-        &lt;/div&gt;
-    &lt;/div&gt;
-&lt;/div&gt;</pre>
+                <button>Save</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+  </div>
+  <div class="codeBlock">
+    <div class="highlight">
+      <pre><span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"link"</span> <span class="na">href=</span><span class="s">"pages/modal-snap.html"</span><span class="nt">&gt;</span>Demo<span class="nt">&lt;/a&gt;</span> 
+
+<span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"view view--modal-snap display--none"</span><span class="nt">&gt;</span>
+    <span class="nt">&lt;header</span> <span class="na">class=</span><span class="s">"view-head"</span><span class="nt">&gt;</span>
+        <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row inverted"</span><span class="nt">&gt;</span> 
+            <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"http://meetup.com/"</span> <span class="na">class=</span><span class="s">"row-item row-item--shrink row-item--alignMiddle"</span><span class="nt">&gt;</span>
+                Close
+            <span class="nt">&lt;/a&gt;</span>
+            <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"row-item row-item--alignMiddle viewHead-heading"</span><span class="nt">&gt;</span>
+                <span class="nt">&lt;h1</span> <span class="na">class=</span><span class="s">"wrap--singleLine--truncate"</span><span class="nt">&gt;</span>Change your setting<span class="nt">&lt;/h1&gt;</span> 
+            <span class="nt">&lt;/div&gt;</span>
+        <span class="nt">&lt;/div&gt;</span>
+    <span class="nt">&lt;/header&gt;</span>
+    <span class="nt">&lt;div</span> <span class="na">id=</span><span class="s">"modal_body"</span> <span class="na">class=</span><span class="s">"view-body"</span><span class="nt">&gt;</span>
+        <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"stripe"</span><span class="nt">&gt;</span>
+            <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"bounds"</span><span class="nt">&gt;</span>
+            ... body content here ...
+
+                <span class="nt">&lt;button&gt;</span>Save<span class="nt">&lt;/button&gt;</span>
+            <span class="nt">&lt;/div&gt;</span>
+        <span class="nt">&lt;/div&gt;</span>
+    <span class="nt">&lt;/div&gt;</span>
+<span class="nt">&lt;/div&gt;</span></pre>
+    </div>
   </div>
 </div>
+
 <h1 id="view" class="styleguide">View</h1>
 <p class="styleguide">A &quot;view&quot; contains all layout and content for a given screen.
 Typically, a document only has a single view. Split views,
@@ -292,9 +366,11 @@ $(function() {
 	//
 	// Disable links by default
 	//
-	$('a').click(function(e) {
-		if ( $(this).hasClass('followLink') ) return;
-		e.preventDefault();
+	$('a').on("click", function(e) {
+		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+			e.preventDefault();
+		}
+		return;
 	});
 
 	//

--- a/docs/build/views.html
+++ b/docs/build/views.html
@@ -111,53 +111,46 @@
 		</nav>
 
 	 	<main id="content" class="stack-item">
-<h1 id="view">View</h1>
-
-<p>A &quot;view&quot; contains all layout and content for a given screen.
+<h1 id="view" class="styleguide">View</h1>
+<p class="styleguide">A &quot;view&quot; contains all layout and content for a given screen.
 Typically, a document only has a single view. Split views,
-where a document contains two view elements are possible (see below).</p>
-
-<p>A class of <code>.view</code> is required for view elements; the
-following classes are optional variants:</p>
-
-<table><thead>
-<tr>
+where a document contains two view elements are possible (see below).</p><p class="styleguide">A class of <code class="styleguide">.view</code> is required for view elements; the
+following classes are optional variants:</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>view--splitList</code></td>
+ <tr>
+<td><code class="styleguide">view--splitList</code></td>
 <td>Sets view to &quot;list style&quot; when viewport is wide enough</td>
 </tr>
 <tr>
-<td><code>view--splitDetail</code></td>
+<td><code class="styleguide">view--splitDetail</code></td>
 <td>Sets view to &quot;detail style&quot; when viewport is wide enough</td>
 </tr>
 <tr>
-<td><code>view--dimmed</code></td>
+<td><code class="styleguide">view--dimmed</code></td>
 <td>Dims view (for use with modal overlays)</td>
 </tr>
-</tbody></table>
-
+ </table>
 <h2>Basic view (<a class="link followLink" href="pages/full-view.html">Demo</a>)</h2>
-
-<p>Basic example of a single view in a document:</p>
-<div class="codeBlock"><div class="highlight"><pre>&lt;div class="view"&gt;
+<p class="styleguide">Basic example of a single view in a document:</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>&lt;div class="view"&gt;
     &lt;header class="view-head"&gt;
         ... view-head ...
     &lt;/header&gt;
     &lt;main class="view-body"&gt;
         ... view-body ...
     &lt;/main&gt;
-&lt;/div&gt;
-</pre></div></div>
+&lt;/div&gt;</pre>
+  </div>
+</div>
 <h2>Split view (DEMO)</h2>
-
-<p>Basic example of two views in one document, where we specify
+<p class="styleguide">Basic example of two views in one document, where we specify
 which view has the &quot;list&quot; responsibility, and which view has
-the &quot;detail&quot; responsibility.</p>
-<div class="codeBlock"><div class="highlight"><pre>&lt;div class="view view--splitList"&gt;
+the &quot;detail&quot; responsibility.</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>&lt;div class="view view--splitList"&gt;
     &lt;header class="view-head"&gt;
         ... view-head ...
     &lt;/header&gt;
@@ -173,53 +166,50 @@ the &quot;detail&quot; responsibility.</p>
     &lt;main class="view-body"&gt;
         ... view-body ...
     &lt;/main&gt;
-&lt;/div&gt;
-</pre></div></div>
-<h1 id="viewBody">View Body</h1>
-
-<p>The <code>view-body</code> element is our main
-content container for the view.</p>
-<div class="codeBlock"><div class="highlight"><pre>&lt;div class="view"&gt;
+&lt;/div&gt;</pre>
+  </div>
+</div>
+<h1 id="viewBody" class="styleguide">View Body</h1>
+<p class="styleguide">The <code class="styleguide">view-body</code> element is our main
+content container for the view.</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>&lt;div class="view"&gt;
     &lt;main class="view-body"&gt;
         ... stripes, bounds, etc ...
         ... all content ...
     &lt;/main&gt;
-&lt;/div&gt;
-</pre></div></div>
-<h1 id="viewHead">View Head</h1>
-
-<p>The <code>view-head</code> element is the first child (the
-fixed top nav bar) within every view.</p>
-<div class="codeBlock"><div class="highlight"><pre>&lt;div class="view"&gt;
+&lt;/div&gt;</pre>
+  </div>
+</div>
+<h1 id="viewHead" class="styleguide">View Head</h1>
+<p class="styleguide">The <code class="styleguide">view-head</code> element is the first child (the
+fixed top nav bar) within every view.</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>&lt;div class="view"&gt;
     &lt;header class="view-head row inverted"&gt;
         &lt;a href="#" class="row-item row-item--shrink row-item--alignMiddle"&gt;[...]&lt;/a&gt;
         &lt;a href="#" class="row-item row-item--alignMiddle"&gt;Page Title&lt;/a&gt;
         &lt;a href="#" class="row-item row-item--shrink row-item--alignMiddle"&gt;[...]&lt;/a&gt;
     &lt;/header&gt;
-&lt;/div&gt;
-</pre></div></div>
+&lt;/div&gt;</pre>
+  </div>
+</div>
 <h2>view-head variants</h2>
-
-<p>A class of <code>.view-head</code> is required for view headers. The following classes
+<p class="styleguide">A class of <code class="styleguide">.view-head</code> is required for view headers. The following classes
 are optional variants (most likely added/removed with javascript to accommodate
-hero headers).</p>
-
-<table><thead>
-<tr>
+hero headers).</p><table class="styleguide"> <tr>
 <th>Class</th>
 <th>Description</th>
 </tr>
-</thead><tbody>
-<tr>
-<td><code>.view-head--transparent</code></td>
-<td>Makes view header transparent; hides <code>h1</code> heading</td>
+ <tr>
+<td><code class="styleguide">.view-head--transparent</code></td>
+<td>Makes view header transparent; hides <code class="styleguide">h1</code> heading</td>
 </tr>
 <tr>
-<td><code>.view-head--photoOverlay</code></td>
+<td><code class="styleguide">.view-head--photoOverlay</code></td>
 <td>Same as &#39;transparent&#39; variant, but adds text protext gradient</td>
 </tr>
-</tbody></table>
-	</main>
+ </table>	</main>
 	</section>
 
 <!-- lunr.js search index -->
@@ -506,16 +496,6 @@ $(function() {
 				
 
 				index.add({
-					"title": "Link color",
-					"breadcrumb": "Sass Utils | Mixins & Placeholders > Link color",
-					"path": "sass_utils_|_mixins_&_placeholders.html#linkColor"
-				});
-
-			
-				
-				
-
-				index.add({
 					"title": "Text protection shim",
 					"breadcrumb": "Sass Utils | Mixins & Placeholders > Text protection shim",
 					"path": "sass_utils_|_mixins_&_placeholders.html#textProtection"
@@ -590,8 +570,8 @@ $(function() {
 				
 
 				index.add({
-					"title": "Anchors & Buttons",
-					"breadcrumb": "Modifier Classes > Anchors & Buttons",
+					"title": "Anchors &amp; Buttons",
+					"breadcrumb": "Modifier Classes > Anchors &amp; Buttons",
 					"path": "modifier_classes.html#buttonMod"
 				});
 
@@ -921,6 +901,16 @@ $(function() {
 					"title": "Running text",
 					"breadcrumb": "Typography > Running text",
 					"path": "typography.html#runningText"
+				});
+
+			
+				
+				
+
+				index.add({
+					"title": "Link color",
+					"breadcrumb": "Typography > Link color",
+					"path": "typography.html#linkColor"
 				});
 
 			

--- a/docs/pages/modal-full.html
+++ b/docs/pages/modal-full.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<title>Sassquatch 2: Modal snap example</title>
+
+		<!-- Whitney -->
+		<link rel="stylesheet" href="http://static1.meetupstatic.com/fonts/whitney.css" type="text/css" />
+
+		<!-- Styleguide CSS -->
+		<link rel="stylesheet" href="../css/doc.css">
+		<link rel="stylesheet" href="../css/github.css">
+
+		<!-- CSS to be documented -->
+		<link rel="stylesheet" href="../css/sassquatch.css">
+		<script type="text/javascript" src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
+	</head>
+
+
+
+
+
+	<body>
+		<button id="demo" class="button button--primary">Show Me</button>	
+		<div id="modal" class="view view--modal-full display--none">
+			<header id="modal_header" class="view-head">
+				<div class="row inverted"> 
+					<div class="row-item row-item--alignMiddle viewHead-heading">
+						<h1 class="wrap--singleLine--truncate">Group Settings</h1> 
+					</div>
+					<div class="viewHead-actions row row-item row-item--shrink row-item--alignMiddle">
+						<a href="#" class="j-close">Close</a>
+					</div>
+				</div>
+			</header>
+			<div id="modal_body" class="view-body">
+				<div class="stripe">
+					<div class="bounds">
+						<div class="chunk">
+							<div class="row">
+								<div class="row-item--shrink">
+									<input type="checkbox" />
+								</div> 
+								<div class="row-item">Some Group Setting</div>
+							</div>
+						</div>
+						<div class="chunk">
+							<div class="row">
+								<div class="row-item--shrink">
+									<input type="checkbox" />
+								</div> 
+								<div class="row-item">Some Group Setting</div>
+							</div>
+						</div>
+						<div class="chunk">
+							<div class="row">
+								<div class="row-item--shrink">
+									<input type="checkbox" />
+								</div> 
+								<div class="row-item">Some Group Setting</div>
+							</div>
+						</div>
+						<div class="chunk">
+							<div class="row">
+								<div class="row-item--shrink">
+									<input type="checkbox" />
+								</div> 
+								<div class="row-item">Some Group Setting</div>
+							</div>
+						</div>
+						<div class="chunk">
+							<div class="row">
+								<div class="row-item--shrink">
+									<input type="checkbox" />
+								</div> 
+								<div class="row-item">Some Group Setting</div>
+							</div>
+						</div>
+						<div class="chunk">
+							<div class="row">
+								<div class="row-item--shrink row-item--alignMiddle">
+									<a href="#" class="button button--primary">Save</a>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<script>
+			$(function() {
+				$("#demo").on("click", function(e) {
+					e.preventDefault();
+					$("#modal").removeClass("display--none");
+
+				});	
+				$(".j-close").on("click", function(e) {
+					e.preventDefault();
+					$("#modal").addClass("display--none");
+				});
+			});
+		</script>
+	</body>
+</html>
+

--- a/docs/pages/modal-full.html
+++ b/docs/pages/modal-full.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 
-		<title>Sassquatch 2: Modal snap example</title>
+		<title>Sassquatch 2: Modal Full example</title>
 
 		<!-- Whitney -->
 		<link rel="stylesheet" href="http://static1.meetupstatic.com/fonts/whitney.css" type="text/css" />
@@ -24,7 +24,7 @@
 
 	<body>
 		<button id="demo" class="button button--primary">Show Me</button>	
-		<div id="modal" class="view view--modal-full display--none">
+		<div id="modal" class="view view--modalFull display--none">
 			<header id="modal_header" class="view-head">
 				<div class="row inverted"> 
 					<div class="row-item row-item--alignMiddle viewHead-heading">

--- a/docs/pages/modal-snap.html
+++ b/docs/pages/modal-snap.html
@@ -20,7 +20,7 @@
 
 	<body>
 		<button id="demo" class="button button--primary">Show Me</button>	
-		<div id="modal" class="view view--modal-snap display--none">
+		<div id="modal" class="view view--modalSnap display--none">
 			<header id="modal_header" class="view-head">
 				<div class="row inverted"> 
 					<div class="row-item row-item--alignMiddle viewHead-heading">

--- a/docs/pages/modal-snap.html
+++ b/docs/pages/modal-snap.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<title>Sassquatch 2: Modal snap example</title>
+
+		<!-- Whitney -->
+		<link rel="stylesheet" href="http://static1.meetupstatic.com/fonts/whitney.css" type="text/css" />
+
+		<!-- Styleguide CSS -->
+		<link rel="stylesheet" href="../css/doc.css">
+		<link rel="stylesheet" href="../css/github.css">
+
+		<!-- CSS to be documented -->
+		<link rel="stylesheet" href="../css/sassquatch.css">
+		<script type="text/javascript" src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
+	</head>
+
+	<body>
+		<button id="demo" class="button button--primary">Show Me</button>	
+		<div id="modal" class="view view--modal-snap display--none">
+			<header id="modal_header" class="view-head">
+				<div class="row inverted"> 
+					<div class="row-item row-item--alignMiddle viewHead-heading">
+						<h1 class="wrap--singleLine--truncate">Send a message...</h1> 
+					</div>
+					<div class="viewHead-actions row row-item row-item--shrink row-item--alignMiddle">
+						<a href="#" class="j-close">Close</a>
+					</div>
+				</div>
+			</header>
+			<div id="modal_body" class="view-body">
+				<div class="stripe">
+					<div class="bounds">
+						<div class="chunk">
+							<div class="row">
+								<div class="row-item--shrink">
+									<div class="avatar avatar--person avatar--small" style="background-image: url(http://api.randomuser.me/0.3/portraits/women/7.jpg);"></div>
+								</div> 
+								<div class="row-item">Sally Smeetup</div>
+							</div>
+						</div>
+						<div class="chunk">
+							<textarea id="post-textarea"></textarea>
+						</div>
+						<div class="chunk">
+							<div class="row">
+								<div class="row-item--shrink row-item--alignMiddle">
+									<a href="#" class="button button--primary">Post</a>
+								</div>
+								<div class="row-item row-item--alignMiddle">
+									<p class="text--caption">Visible to: members and non-members</p>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</body>
+	<script>
+		$(function() {
+			$("#demo").on("click", function(e) {
+				e.preventDefault();
+				$("#modal").removeClass("display--none");
+			});	
+			$(".j-close").on("click", function(e) {
+				e.preventDefault();
+				$("#modal").addClass("display--none");
+			});
+		});
+	</script>
+</html>
+
+

--- a/docs/templates/_footer.html
+++ b/docs/templates/_footer.html
@@ -29,6 +29,13 @@ $(function() {
 		});
 	}
 
+
+	// TODO: modal code
+
+
+
+
+
 	//
 	// lunr search index
 	//

--- a/docs/templates/_footer.html
+++ b/docs/templates/_footer.html
@@ -7,10 +7,10 @@
 <script type="text/javascript">
 $(function() {
 	//
-	// Disable links by default
+	// Disable links without real href
 	//
 	$('a').on("click", function(e) {
-		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+		if ( this.getAttribute("href") == "#" || $(this).hasClass('noFollow') ) {
 			e.preventDefault();
 		}
 		return;
@@ -30,13 +30,6 @@ $(function() {
 			}
 		});
 	}
-
-
-	// TODO: modal code
-
-
-
-
 
 	//
 	// lunr search index

--- a/docs/templates/_footer.html
+++ b/docs/templates/_footer.html
@@ -9,9 +9,11 @@ $(function() {
 	//
 	// Disable links by default
 	//
-	$('a').click(function(e) {
-		if ( $(this).hasClass('followLink') ) return;
-		e.preventDefault();
+	$('a').on("click", function(e) {
+		if ( this.href == "#" || $(this).hasClass('noFollow') ) {
+			e.preventDefault();
+		}
+		return;
 	});
 
 	//

--- a/docs/templates/css/sassquatch.css
+++ b/docs/templates/css/sassquatch.css
@@ -490,7 +490,7 @@ title: Modal Dialog Mixin
 parent: modalUtils
 ---
 
-Use this mixin to get the behavior of a [link Snap Modal View][snapModalView],
+Use this mixin to get the behavior of a [Snap Modal View][snapModalView],
 a view that snaps to full page on small screens and a dialog on larger formats.
 
 ```
@@ -505,7 +505,7 @@ parent: modalUtils
 ---
 
 Use this mixin to get behavior of a full page modal.
-See [link the Full Modal View documentation][fullModalView]
+See [the Full Modal View documentation][fullModalView]
 
 ```
 	@include modal-full;
@@ -2659,18 +2659,29 @@ title: Modals
 name: modals
 category: Views
 ---
+
+## view--modal variants
+
+Class                      | Description
+-------------------------- | ---------------------------
+`.view-modal--full`        | Makes a modal that is full screen on all screen sizes
+`.view-modal--snap`        | Creates a modal that is full screen on small sizes, overlay/dialog on larger screens
+
+
 */
 /*doc
 ---
-title: Full Modal View
+title: Full Modal View 
 name: fullModalView
 parent: modals
 ---
 
 Modal that is presented full screen on all sizes
 
-```
-<div class="view view--modal-full">
+```html_example
+<a class="link" href="pages/modal-full.html">Demo</a> 
+
+<div class="view view--modal-full display--none">
 	<header class="view-head">
 		<div class="row inverted"> 
 			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
@@ -2690,47 +2701,7 @@ Modal that is presented full screen on all sizes
 	</div>
 </div>
 ```
-*/
-/* TODO make demo page with code
-<div id="fullModal" class="view view--modal-full">
-	<header id="modal_header" class="view-head">
-		<div class="row inverted"> 
-			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
-			<img src="style/img/logo.svg" width="35" height="24"></a>
-			<div class="row-item row-item--alignMiddle viewHead-heading">
-				<h1 class="wrap--singleLine--truncate">Text post</h1> 
-			</div>
-			<div class="viewHead-actions row row-item row-item--shrink row-item--alignMiddle"> </div>
-		</div>
-	</header>
-	<div id="modal_body" class="view-body">
-		<div class="stripe">
-			<div class="bounds">
-				<div class="chunk">
-					<div class="row">
-						<div class="row-item--shrink">
-							<div class="avatar avatar--person avatar--small" style="background-image: url(http://api.randomuser.me/0.3/portraits/women/7.jpg);"></div>
-						</div> 
-						<div class="row-item">Sally Smeetup</div>
-					</div>
-				</div>
-				<div class="chunk">
-					<textarea id="post-textarea"></textarea>
-				</div>
-				<div class="chunk">
-					<div class="row">
-						<div class="row-item--shrink row-item--alignMiddle">
-							<a href="#" class="button button--primary">Post</a>
-						</div>
-						<div class="row-item row-item--alignMiddle">
-							<p class="text--caption">Visible to: members and non-members</p>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-</div>
+
 */
 .view--modal-full {
   -webkit-transform: translate3d(0, 0, 0);
@@ -2753,7 +2724,7 @@ Modal that is presented full screen on all sizes
 
 /*doc
 ---
-title: Snap Modal View (Dialog)
+title: Snap Modal View (Dialog) 
 name: snapModalView
 parent: modals
 ---
@@ -2761,8 +2732,11 @@ parent: modals
 Modal that snaps to the whole viewport and is full screen on small screens,
 lays out as a dialog on background content on larger screens.
 
-```
-<div class="view view--modal-snap">
+
+```html_example
+<a class="link" href="pages/modal-snap.html">Demo</a> 
+
+<div class="view view--modal-snap display--none">
 	<header class="view-head">
 		<div class="row inverted"> 
 			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
@@ -2778,53 +2752,12 @@ lays out as a dialog on background content on larger screens.
 			<div class="bounds">
 			... body content here ...
 			
-			<button>Save</button>
+				<button>Save</button>
 			</div>
 		</div>
 	</div>
 </div>
 ```
-*/
-/* TODO demo page
-<div id="modal" class="view view--modal-snap">
-	<header id="modal_header" class="view-head">
-		<div class="row inverted"> 
-			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
-			<img src="style/img/logo.svg" width="35" height="24"></a>
-			<div class="row-item row-item--alignMiddle viewHead-heading">
-				<h1 class="wrap--singleLine--truncate">Text post</h1> 
-			</div>
-			<div class="viewHead-actions row row-item row-item--shrink row-item--alignMiddle"> </div>
-		</div>
-	</header>
-	<div id="modal_body" class="view-body">
-		<div class="stripe">
-			<div class="bounds">
-				<div class="chunk">
-					<div class="row">
-						<div class="row-item--shrink">
-							<div class="avatar avatar--person avatar--small" style="background-image: url(http://api.randomuser.me/0.3/portraits/women/7.jpg);"></div>
-						</div> 
-						<div class="row-item">Sally Smeetup</div>
-					</div>
-				</div>
-				<div class="chunk">
-					<textarea id="post-textarea"></textarea>
-				</div>
-				<div class="chunk">
-					<div class="row">
-						<div class="row-item--shrink row-item--alignMiddle">
-							<a href="#" class="button button--primary">Post</a>
-						</div>
-						<div class="row-item row-item--alignMiddle">
-							<p class="text--caption">Visible to: members and non-members</p>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-</div>
 */
 .view--modal-snap {
   -webkit-transform: translate3d(0, 0, 0);

--- a/docs/templates/css/sassquatch.css
+++ b/docs/templates/css/sassquatch.css
@@ -476,6 +476,44 @@ Clears floated children.
 
 /*doc
 ---
+title: Modal mixins
+name: modalUtils
+category: Sass Utils | Mixins & Placeholders
+---
+
+Description here
+
+*/
+/*doc
+---
+title: Modal Dialog Mixin
+parent: modalUtils
+---
+
+Use this mixin to get the behavior of a [link Snap Modal View][snapModalView],
+a view that snaps to full page on small screens and a dialog on larger formats.
+
+```
+	@include modal-dialog;
+
+```
+*/
+/*doc
+---
+title: Modal Full Mixin
+parent: modalUtils
+---
+
+Use this mixin to get behavior of a full page modal.
+See [link the Full Modal View documentation][fullModalView]
+
+```
+	@include modal-full;
+
+```
+*/
+/*doc
+---
 title: Shadow utilities
 name: shadow
 category: Sass Utils | Mixins & Placeholders
@@ -2615,6 +2653,85 @@ content container for the view.
   height: 100vh;
   overflow: auto; }
 
+/*doc
+---
+title: Modals
+name: modals
+category: Views
+---
+*/
+/*doc
+---
+title: Full Modal View
+name: fullModalView
+parent: modals
+---
+
+Modal that is presented full screen on all sizes
+
+```
+<div class="view view--modal-full">
+	<header class="view-head">
+		<div class="row inverted"> 
+			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
+				<img src="style/img/logo.svg" width="35" height="24"></a>
+			</a>
+			<div class="row-item row-item--alignMiddle viewHead-heading">
+				<h1 class="wrap--singleLine--truncate">This is a header</h1> 
+			</div>
+		</div>
+	</header>
+	<div id="modal_body" class="view-body">
+		<div class="stripe">
+			<div class="bounds">
+			... body content here ...
+			</div>
+		</div>
+	</div>
+</div>
+```
+*/
+/* TODO make demo page with code
+<div id="fullModal" class="view view--modal-full">
+	<header id="modal_header" class="view-head">
+		<div class="row inverted"> 
+			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
+			<img src="style/img/logo.svg" width="35" height="24"></a>
+			<div class="row-item row-item--alignMiddle viewHead-heading">
+				<h1 class="wrap--singleLine--truncate">Text post</h1> 
+			</div>
+			<div class="viewHead-actions row row-item row-item--shrink row-item--alignMiddle"> </div>
+		</div>
+	</header>
+	<div id="modal_body" class="view-body">
+		<div class="stripe">
+			<div class="bounds">
+				<div class="chunk">
+					<div class="row">
+						<div class="row-item--shrink">
+							<div class="avatar avatar--person avatar--small" style="background-image: url(http://api.randomuser.me/0.3/portraits/women/7.jpg);"></div>
+						</div> 
+						<div class="row-item">Sally Smeetup</div>
+					</div>
+				</div>
+				<div class="chunk">
+					<textarea id="post-textarea"></textarea>
+				</div>
+				<div class="chunk">
+					<div class="row">
+						<div class="row-item--shrink row-item--alignMiddle">
+							<a href="#" class="button button--primary">Post</a>
+						</div>
+						<div class="row-item row-item--alignMiddle">
+							<p class="text--caption">Visible to: members and non-members</p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+*/
 .view--modal-full {
   -webkit-transform: translate3d(0, 0, 0);
   -ms-transform: translate3d(0, 0, 0);
@@ -2634,6 +2751,81 @@ content container for the view.
     -ms-transform: translateY(100vh);
     transform: translateY(100vh); }
 
+/*doc
+---
+title: Snap Modal View (Dialog)
+name: snapModalView
+parent: modals
+---
+
+Modal that snaps to the whole viewport and is full screen on small screens,
+lays out as a dialog on background content on larger screens.
+
+```
+<div class="view view--modal-snap">
+	<header class="view-head">
+		<div class="row inverted"> 
+			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
+				Close
+			</a>
+			<div class="row-item row-item--alignMiddle viewHead-heading">
+				<h1 class="wrap--singleLine--truncate">Change your setting</h1> 
+			</div>
+		</div>
+	</header>
+	<div id="modal_body" class="view-body">
+		<div class="stripe">
+			<div class="bounds">
+			... body content here ...
+			
+			<button>Save</button>
+			</div>
+		</div>
+	</div>
+</div>
+```
+*/
+/* TODO demo page
+<div id="modal" class="view view--modal-snap">
+	<header id="modal_header" class="view-head">
+		<div class="row inverted"> 
+			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
+			<img src="style/img/logo.svg" width="35" height="24"></a>
+			<div class="row-item row-item--alignMiddle viewHead-heading">
+				<h1 class="wrap--singleLine--truncate">Text post</h1> 
+			</div>
+			<div class="viewHead-actions row row-item row-item--shrink row-item--alignMiddle"> </div>
+		</div>
+	</header>
+	<div id="modal_body" class="view-body">
+		<div class="stripe">
+			<div class="bounds">
+				<div class="chunk">
+					<div class="row">
+						<div class="row-item--shrink">
+							<div class="avatar avatar--person avatar--small" style="background-image: url(http://api.randomuser.me/0.3/portraits/women/7.jpg);"></div>
+						</div> 
+						<div class="row-item">Sally Smeetup</div>
+					</div>
+				</div>
+				<div class="chunk">
+					<textarea id="post-textarea"></textarea>
+				</div>
+				<div class="chunk">
+					<div class="row">
+						<div class="row-item--shrink row-item--alignMiddle">
+							<a href="#" class="button button--primary">Post</a>
+						</div>
+						<div class="row-item row-item--alignMiddle">
+							<p class="text--caption">Visible to: members and non-members</p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+*/
 .view--modal-snap {
   -webkit-transform: translate3d(0, 0, 0);
   -ms-transform: translate3d(0, 0, 0);

--- a/docs/templates/css/sassquatch.css
+++ b/docs/templates/css/sassquatch.css
@@ -2664,8 +2664,8 @@ category: Views
 
 Class                      | Description
 -------------------------- | ---------------------------
-`.view-modal--full`        | Makes a modal that is full screen on all screen sizes
-`.view-modal--snap`        | Creates a modal that is full screen on small sizes, overlay/dialog on larger screens
+`.view--modalFull`        | Makes a modal that is full screen on all screen sizes
+`.view--modalSnap`        | Creates a modal that is full screen on small sizes, overlay/dialog on larger screens
 
 
 */
@@ -2681,7 +2681,7 @@ Modal that is presented full screen on all sizes
 ```html_example
 <a class="link" href="pages/modal-full.html">Demo</a> 
 
-<div class="view view--modal-full display--none">
+<div class="view view--modalFull display--none">
 	<header class="view-head">
 		<div class="row inverted"> 
 			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
@@ -2703,7 +2703,7 @@ Modal that is presented full screen on all sizes
 ```
 
 */
-.view--modal-full {
+.view--modalFull {
   -webkit-transform: translate3d(0, 0, 0);
   -ms-transform: translate3d(0, 0, 0);
   transform: translate3d(0, 0, 0);
@@ -2717,7 +2717,7 @@ Modal that is presented full screen on all sizes
   top: 0;
   width: 100%;
   z-index: 3; }
-  .view--modal-full.off {
+  .view--modalFull.off {
     -webkit-transform: translateY(100vh);
     -ms-transform: translateY(100vh);
     transform: translateY(100vh); }
@@ -2736,7 +2736,7 @@ lays out as a dialog on background content on larger screens.
 ```html_example
 <a class="link" href="pages/modal-snap.html">Demo</a> 
 
-<div class="view view--modal-snap display--none">
+<div class="view view--modalSnap display--none">
 	<header class="view-head">
 		<div class="row inverted"> 
 			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
@@ -2759,7 +2759,7 @@ lays out as a dialog on background content on larger screens.
 </div>
 ```
 */
-.view--modal-snap {
+.view--modalSnap {
   -webkit-transform: translate3d(0, 0, 0);
   -ms-transform: translate3d(0, 0, 0);
   transform: translate3d(0, 0, 0);
@@ -2773,12 +2773,12 @@ lays out as a dialog on background content on larger screens.
   position: absolute;
   width: 440px;
   z-index: 3; }
-  .view--modal-snap.off {
+  .view--modalSnap.off {
     -webkit-transform: translateY(100vh);
     -ms-transform: translateY(100vh);
     transform: translateY(100vh); }
   @media only screen and (max-width: 440px) {
-    .view--modal-snap {
+    .view--modalSnap {
       -webkit-transform: translate3d(0, 0, 0);
       -ms-transform: translate3d(0, 0, 0);
       transform: translate3d(0, 0, 0);
@@ -2791,7 +2791,7 @@ lays out as a dialog on background content on larger screens.
       position: absolute;
       top: 0;
       width: 100%; }
-      .view--modal-snap.off {
+      .view--modalSnap.off {
         -webkit-transform: translateY(100vh);
         -ms-transform: translateY(100vh);
         transform: translateY(100vh); } }

--- a/docs/templates/css/sassquatch.css
+++ b/docs/templates/css/sassquatch.css
@@ -2499,7 +2499,8 @@ the "detail" responsibility.
   box-sizing: border-box;
   background: white;
   width: 100%;
-  min-height: 100vh; }
+  min-height: 100vh;
+  position: relative; }
 
 .view--splitList, .view--splitDetail {
   display: none; }
@@ -2555,7 +2556,6 @@ Class                      | Description
   background: #d55741;
   color: white;
   left: 0;
-  position: fixed;
   top: 0;
   width: 100%;
   z-index: 1;
@@ -2577,7 +2577,8 @@ Class                      | Description
 .view-head--transparent {
   background: transparent;
   border-bottom: none;
-  color: white; }
+  color: white;
+  position: absolute; }
   .view-head--photoOverlay h1,
   .view-head--transparent h1 {
     opacity: 0; }
@@ -2907,12 +2908,10 @@ _Ancestry only affects spacing in `attachment`. Text sizing remains explicit._
 @media only screen and (min-width: 640px) {
   .attachment.atMedium_stack--spread .stack-item,
   .attachment .atMedium_stack--spread .stack-item {
-    outline: 20px solid red;
     padding-left: 8px; } }
 @media only screen and (min-width: 840px) {
   .attachment.atLarge_stack--spread .stack-item,
   .attachment .atLarge_stack--spread .stack-item {
-    outline: 20px solid red;
     padding-left: 8px; } }
 .attachment.chunk,
 .attachment .chunk {
@@ -3256,8 +3255,11 @@ _(The inline style on the card element is for documentation purposes only)_
     right: -1px;
     top: -1px; }
 
+.card--event--past:before {
+  background: #e6e9ec; }
+
 .card--event--canceled:before {
-  background: #353e48; }
+  background: #e6e9ec; }
 
 .card--event--featured:before {
   background: #f0cb4f; }

--- a/sass/core/view/_modal.scss
+++ b/sass/core/view/_modal.scss
@@ -1,15 +1,174 @@
-// TODO: needs docs and cleanup
+/*doc
+---
+title: Modals
+name: modals
+category: Views
+---
+*/
 
+/*doc
+---
+title: Full Modal View
+name: fullModalView
+parent: modals
+---
+
+Modal that is presented full screen on all sizes
+
+```
+<div class="view view--modal-full">
+	<header class="view-head">
+		<div class="row inverted"> 
+			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
+				<img src="style/img/logo.svg" width="35" height="24"></a>
+			</a>
+			<div class="row-item row-item--alignMiddle viewHead-heading">
+				<h1 class="wrap--singleLine--truncate">This is a header</h1> 
+			</div>
+		</div>
+	</header>
+	<div id="modal_body" class="view-body">
+		<div class="stripe">
+			<div class="bounds">
+			... body content here ...
+			</div>
+		</div>
+	</div>
+</div>
+```
+*/
+
+/* TODO make demo page with code
+<div id="fullModal" class="view view--modal-full">
+	<header id="modal_header" class="view-head">
+		<div class="row inverted"> 
+			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
+			<img src="style/img/logo.svg" width="35" height="24"></a>
+			<div class="row-item row-item--alignMiddle viewHead-heading">
+				<h1 class="wrap--singleLine--truncate">Text post</h1> 
+			</div>
+			<div class="viewHead-actions row row-item row-item--shrink row-item--alignMiddle"> </div>
+		</div>
+	</header>
+	<div id="modal_body" class="view-body">
+		<div class="stripe">
+			<div class="bounds">
+				<div class="chunk">
+					<div class="row">
+						<div class="row-item--shrink">
+							<div class="avatar avatar--person avatar--small" style="background-image: url(http://api.randomuser.me/0.3/portraits/women/7.jpg);"></div>
+						</div> 
+						<div class="row-item">Sally Smeetup</div>
+					</div>
+				</div>
+				<div class="chunk">
+					<textarea id="post-textarea"></textarea>
+				</div>
+				<div class="chunk">
+					<div class="row">
+						<div class="row-item--shrink row-item--alignMiddle">
+							<a href="#" class="button button--primary">Post</a>
+						</div>
+						<div class="row-item row-item--alignMiddle">
+							<p class="text--caption">Visible to: members and non-members</p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+*/
 
 // MODAL VIEW FULL
 // full screen at all screen widths
+
 .view--modal-full {
 	@include modal-full;
 	z-index: map-get($zindex-map, "modal");
 }
 
+/*doc
+---
+title: Snap Modal View (Dialog)
+name: snapModalView
+parent: modals
+---
+
+Modal that snaps to the whole viewport and is full screen on small screens,
+lays out as a dialog on background content on larger screens.
+
+```
+<div class="view view--modal-snap">
+	<header class="view-head">
+		<div class="row inverted"> 
+			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
+				Close
+			</a>
+			<div class="row-item row-item--alignMiddle viewHead-heading">
+				<h1 class="wrap--singleLine--truncate">Change your setting</h1> 
+			</div>
+		</div>
+	</header>
+	<div id="modal_body" class="view-body">
+		<div class="stripe">
+			<div class="bounds">
+			... body content here ...
+			
+			<button>Save</button>
+			</div>
+		</div>
+	</div>
+</div>
+```
+*/
+
+
+/* TODO demo page
+<div id="modal" class="view view--modal-snap">
+	<header id="modal_header" class="view-head">
+		<div class="row inverted"> 
+			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
+			<img src="style/img/logo.svg" width="35" height="24"></a>
+			<div class="row-item row-item--alignMiddle viewHead-heading">
+				<h1 class="wrap--singleLine--truncate">Text post</h1> 
+			</div>
+			<div class="viewHead-actions row row-item row-item--shrink row-item--alignMiddle"> </div>
+		</div>
+	</header>
+	<div id="modal_body" class="view-body">
+		<div class="stripe">
+			<div class="bounds">
+				<div class="chunk">
+					<div class="row">
+						<div class="row-item--shrink">
+							<div class="avatar avatar--person avatar--small" style="background-image: url(http://api.randomuser.me/0.3/portraits/women/7.jpg);"></div>
+						</div> 
+						<div class="row-item">Sally Smeetup</div>
+					</div>
+				</div>
+				<div class="chunk">
+					<textarea id="post-textarea"></textarea>
+				</div>
+				<div class="chunk">
+					<div class="row">
+						<div class="row-item--shrink row-item--alignMiddle">
+							<a href="#" class="button button--primary">Post</a>
+						</div>
+						<div class="row-item row-item--alignMiddle">
+							<p class="text--caption">Visible to: members and non-members</p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+*/
+
 // MODAL VIEW SNAP
 // full at narrow widths, dialog at wide widths
+
 .view--modal-snap {
 	@include modal-dialog;
 	@include atMediaDown(small){

--- a/sass/core/view/_modal.scss
+++ b/sass/core/view/_modal.scss
@@ -4,19 +4,30 @@ title: Modals
 name: modals
 category: Views
 ---
+
+## view--modal variants
+
+Class                      | Description
+-------------------------- | ---------------------------
+`.view-modal--full`        | Makes a modal that is full screen on all screen sizes
+`.view-modal--snap`        | Creates a modal that is full screen on small sizes, overlay/dialog on larger screens
+
+
 */
 
 /*doc
 ---
-title: Full Modal View
+title: Full Modal View 
 name: fullModalView
 parent: modals
 ---
 
 Modal that is presented full screen on all sizes
 
-```
-<div class="view view--modal-full">
+```html_example
+<a class="link" href="pages/modal-full.html">Demo</a> 
+
+<div class="view view--modal-full display--none">
 	<header class="view-head">
 		<div class="row inverted"> 
 			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
@@ -36,48 +47,7 @@ Modal that is presented full screen on all sizes
 	</div>
 </div>
 ```
-*/
 
-/* TODO make demo page with code
-<div id="fullModal" class="view view--modal-full">
-	<header id="modal_header" class="view-head">
-		<div class="row inverted"> 
-			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
-			<img src="style/img/logo.svg" width="35" height="24"></a>
-			<div class="row-item row-item--alignMiddle viewHead-heading">
-				<h1 class="wrap--singleLine--truncate">Text post</h1> 
-			</div>
-			<div class="viewHead-actions row row-item row-item--shrink row-item--alignMiddle"> </div>
-		</div>
-	</header>
-	<div id="modal_body" class="view-body">
-		<div class="stripe">
-			<div class="bounds">
-				<div class="chunk">
-					<div class="row">
-						<div class="row-item--shrink">
-							<div class="avatar avatar--person avatar--small" style="background-image: url(http://api.randomuser.me/0.3/portraits/women/7.jpg);"></div>
-						</div> 
-						<div class="row-item">Sally Smeetup</div>
-					</div>
-				</div>
-				<div class="chunk">
-					<textarea id="post-textarea"></textarea>
-				</div>
-				<div class="chunk">
-					<div class="row">
-						<div class="row-item--shrink row-item--alignMiddle">
-							<a href="#" class="button button--primary">Post</a>
-						</div>
-						<div class="row-item row-item--alignMiddle">
-							<p class="text--caption">Visible to: members and non-members</p>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-</div>
 */
 
 // MODAL VIEW FULL
@@ -90,7 +60,7 @@ Modal that is presented full screen on all sizes
 
 /*doc
 ---
-title: Snap Modal View (Dialog)
+title: Snap Modal View (Dialog) 
 name: snapModalView
 parent: modals
 ---
@@ -98,8 +68,11 @@ parent: modals
 Modal that snaps to the whole viewport and is full screen on small screens,
 lays out as a dialog on background content on larger screens.
 
-```
-<div class="view view--modal-snap">
+
+```html_example
+<a class="link" href="pages/modal-snap.html">Demo</a> 
+
+<div class="view view--modal-snap display--none">
 	<header class="view-head">
 		<div class="row inverted"> 
 			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
@@ -115,55 +88,12 @@ lays out as a dialog on background content on larger screens.
 			<div class="bounds">
 			... body content here ...
 			
-			<button>Save</button>
+				<button>Save</button>
 			</div>
 		</div>
 	</div>
 </div>
 ```
-*/
-
-
-/* TODO demo page
-<div id="modal" class="view view--modal-snap">
-	<header id="modal_header" class="view-head">
-		<div class="row inverted"> 
-			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
-			<img src="style/img/logo.svg" width="35" height="24"></a>
-			<div class="row-item row-item--alignMiddle viewHead-heading">
-				<h1 class="wrap--singleLine--truncate">Text post</h1> 
-			</div>
-			<div class="viewHead-actions row row-item row-item--shrink row-item--alignMiddle"> </div>
-		</div>
-	</header>
-	<div id="modal_body" class="view-body">
-		<div class="stripe">
-			<div class="bounds">
-				<div class="chunk">
-					<div class="row">
-						<div class="row-item--shrink">
-							<div class="avatar avatar--person avatar--small" style="background-image: url(http://api.randomuser.me/0.3/portraits/women/7.jpg);"></div>
-						</div> 
-						<div class="row-item">Sally Smeetup</div>
-					</div>
-				</div>
-				<div class="chunk">
-					<textarea id="post-textarea"></textarea>
-				</div>
-				<div class="chunk">
-					<div class="row">
-						<div class="row-item--shrink row-item--alignMiddle">
-							<a href="#" class="button button--primary">Post</a>
-						</div>
-						<div class="row-item row-item--alignMiddle">
-							<p class="text--caption">Visible to: members and non-members</p>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-</div>
 */
 
 // MODAL VIEW SNAP

--- a/sass/core/view/_modal.scss
+++ b/sass/core/view/_modal.scss
@@ -9,8 +9,8 @@ category: Views
 
 Class                      | Description
 -------------------------- | ---------------------------
-`.view-modal--full`        | Makes a modal that is full screen on all screen sizes
-`.view-modal--snap`        | Creates a modal that is full screen on small sizes, overlay/dialog on larger screens
+`.view--modalFull`        | Makes a modal that is full screen on all screen sizes
+`.view--modalSnap`        | Creates a modal that is full screen on small sizes, overlay/dialog on larger screens
 
 
 */
@@ -27,7 +27,7 @@ Modal that is presented full screen on all sizes
 ```html_example
 <a class="link" href="pages/modal-full.html">Demo</a> 
 
-<div class="view view--modal-full display--none">
+<div class="view view--modalFull display--none">
 	<header class="view-head">
 		<div class="row inverted"> 
 			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
@@ -53,7 +53,7 @@ Modal that is presented full screen on all sizes
 // MODAL VIEW FULL
 // full screen at all screen widths
 
-.view--modal-full {
+.view--modalFull {
 	@include modal-full;
 	z-index: map-get($zindex-map, "modal");
 }
@@ -72,7 +72,7 @@ lays out as a dialog on background content on larger screens.
 ```html_example
 <a class="link" href="pages/modal-snap.html">Demo</a> 
 
-<div class="view view--modal-snap display--none">
+<div class="view view--modalSnap display--none">
 	<header class="view-head">
 		<div class="row inverted"> 
 			<a href="http://meetup.com/" class="row-item row-item--shrink row-item--alignMiddle">
@@ -99,7 +99,7 @@ lays out as a dialog on background content on larger screens.
 // MODAL VIEW SNAP
 // full at narrow widths, dialog at wide widths
 
-.view--modal-snap {
+.view--modalSnap {
 	@include modal-dialog;
 	@include atMediaDown(small){
 		@include modal-full;

--- a/sass/util/_modal.scss
+++ b/sass/util/_modal.scss
@@ -1,5 +1,3 @@
-//TODO: doc and/or rewrite
-
 /*doc
 ---
 title: Modal mixins

--- a/sass/util/_modal.scss
+++ b/sass/util/_modal.scss
@@ -1,4 +1,31 @@
 //TODO: doc and/or rewrite
+
+/*doc
+---
+title: Modal mixins
+name: modalUtils
+category: Sass Utils | Mixins & Placeholders
+---
+
+Description here
+
+*/
+
+/*doc
+---
+title: Modal Dialog Mixin
+parent: modalUtils
+---
+
+Use this mixin to get the behavior of a [Snap Modal View][snapModalView],
+a view that snaps to full page on small screens and a dialog on larger formats.
+
+```
+	@include modal-dialog;
+
+```
+*/
+
 @mixin modal-dialog{
 	@include transform( translate3d(0, 0, 0) );
 	@include transition(transform .2s ease);
@@ -13,6 +40,21 @@
 	  @include transform( translateY(100vh) );
 	}
   }
+
+/*doc
+---
+title: Modal Full Mixin
+parent: modalUtils
+---
+
+Use this mixin to get behavior of a full page modal.
+See [the Full Modal View documentation][fullModalView]
+
+```
+	@include modal-full;
+
+```
+*/
 
 @mixin modal-full{
 	@include transform( translate3d(0, 0, 0) );


### PR DESCRIPTION
I didn't touch the actual modal css definitions.
I cleaned up the docs and created very lo-fi demo pages.

let me know if there is any code to change in views/_modals or utils/_modals based on sassquatch2 standards.

also, #navigation column is still a bit wide.