### PR TITLE
hscroll-content--cards

### DIFF
--- a/sass/core/layout/_hscroll.scss
+++ b/sass/core/layout/_hscroll.scss
@@ -8,7 +8,62 @@ Applies styles for horizontal scrolling lists.
 
 ```html_example
 <div class="hscroll">
-	<ul class="hscroll-content">
+	<ul class="hscroll-content hscroll-content--cards">
+		<li>
+			<p>This is some content in an hscroll list. It can be almost anything.</p>
+			<a class="button">Button</a>
+		</li>
+		<li>
+			<p>This is some content in an hscroll list. It can be almost anything.</p>
+			<a class="button">Button</a>
+		</li>
+		<li>
+			<p>This is some content in an hscroll list. It can be almost anything.</p>
+			<a class="button">Button</a>
+		</li>
+		<li>
+			<p>This is some content in an hscroll list. It can be almost anything.</p>
+			<a class="button">Button</a>
+		</li>
+		<li>
+			<p>This is some content in an hscroll list. It can be almost anything.</p>
+			<a class="button">Button</a>
+		</li>
+		<li>
+			<p>This is some content in an hscroll list. It can be almost anything.</p>
+			<a class="button">Button</a>
+		</li>
+		<li>
+			<p>This is some content in an hscroll list. It can be almost anything.</p>
+			<a class="button">Button</a>
+		</li>
+		<li>
+			<p>This is some content in an hscroll list. It can be almost anything.</p>
+			<a class="button">Button</a>
+		</li>
+		<li>
+			<p>This is some content in an hscroll list. It can be almost anything.</p>
+			<a class="button">Button</a>
+		</li>
+		<li>
+			<p>This is some content in an hscroll list. It can be almost anything.</p>
+			<a class="button">Button</a>
+		</li>
+		<li>
+			<p>This is some content in an hscroll list. It can be almost anything.</p>
+			<a class="button">Button</a>
+		</li>
+		<li>
+			<p>This is some content in an hscroll list. It can be almost anything.</p>
+			<a class="button">Button</a>
+		</li>
+	</ul>
+</div>
+```
+
+```html_example
+<div class="hscroll">
+	<ul class="hscroll-content hscroll-content--cards">
 		<li>
 			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
 				<div class="card--group-content">

--- a/sass/core/layout/_hscroll.scss
+++ b/sass/core/layout/_hscroll.scss
@@ -8,7 +8,7 @@ Applies styles for horizontal scrolling lists.
 
 ```html_example
 <div class="hscroll">
-	<ul class="hscroll-content hscroll-content--cards">
+	<ul class="hscroll-content">
 		<li>
 			<p>This is some content in an hscroll list. It can be almost anything.</p>
 			<a class="button">Button</a>
@@ -170,7 +170,7 @@ into a non-scrolling list in the document flow for larger screens.
 
 ```html_example
 <div class="hscroll atMedium_hscroll--unclip">
-	<ul class="hscroll-content">
+	<ul class="hscroll-content hscroll-content--cards">
 		<li>
 			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
 				<div class="card--group-content">

--- a/sass/core/layout/_hscroll.scss
+++ b/sass/core/layout/_hscroll.scss
@@ -9,18 +9,102 @@ Applies styles for horizontal scrolling lists.
 ```html_example
 <div class="hscroll">
 	<ul class="hscroll-content">
-		<li><img src="https://placekitten.com/g/240/160" /></li>
-		<li><img src="https://placekitten.com/g/240/160" /></li>
-		<li><img src="https://placekitten.com/g/240/160" /></li>
-		<li><img src="https://placekitten.com/g/240/160" /></li>
-		<li><img src="https://placekitten.com/g/240/160" /></li>
-		<li><img src="https://placekitten.com/g/240/160" /></li>
-		<li><img src="https://placekitten.com/g/240/160" /></li>
-		<li><img src="https://placekitten.com/g/240/160" /></li>
-		<li><img src="https://placekitten.com/g/240/160" /></li>
-		<li><img src="https://placekitten.com/g/240/160" /></li>
-		<li><img src="https://placekitten.com/g/240/160" /></li>
-		<li><img src="https://placekitten.com/g/240/160" /></li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
 	</ul>
 </div>
 ```
@@ -32,12 +116,54 @@ into a non-scrolling list in the document flow for larger screens.
 ```html_example
 <div class="hscroll atMedium_hscroll--unclip">
 	<ul class="hscroll-content">
-		<li><img src="https://placekitten.com/g/200/120" /></li>
-		<li><img src="https://placekitten.com/g/200/120" /></li>
-		<li><img src="https://placekitten.com/g/200/120" /></li>
-		<li><img src="https://placekitten.com/g/200/120" /></li>
-		<li><img src="https://placekitten.com/g/200/120" /></li>
-		<li><img src="https://placekitten.com/g/200/120" /></li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
+		<li>
+			<a class="card card--group inverted" href="http://www.dev.meetup.com/New-York-City-Social-Group/" style="background-image: url(http://photos1.dev.meetupstatic.com/photos/event/1/b/3/2/600_406026962.jpeg);">
+				<div class="card--group-content">
+					<h4 class="text--bold">New York City Social Group</h4>
+					<p>979 Members</p>
+				</div>
+			</a>
+		</li>
 	</ul>
 </div>
 ```
@@ -60,14 +186,11 @@ Class                       | Description
 	@extend %inlineblockList;
 	box-sizing: content-box;
 	white-space: nowrap;
+}
+
+.hscroll-content--cards {
 	> li {
-		// avoid whitespace between <li>s to ensure
-		// consistent spacing on all browsers
-		white-space: normal;
-	}
-	.card {
-		width: 100%;
-		max-width: $block-5;
+		width: $block-5;
 	}
 }
 


### PR DESCRIPTION
needed a card-specific variant of hscroll-content in order to get the correct card sizing

the `white-space: normal` rule causes the cards to not be vertically aligned when you have real content in them (e.g. a group card - probably worth using more representative card content in the doc examples)