### PR TITLE
Align sideHeaders to the right

### DIFF
--- a/sass/core/layout/_bounds.scss
+++ b/sass/core/layout/_bounds.scss
@@ -92,6 +92,7 @@ $sideHeadergutter: $bounds-wide - $bounds;
 		top: $space-bounds;
 		left: $space;
 		width: $sideHeadergutter - $space-bounds;
+		text-align: right;
 	}
 }
 


### PR DESCRIPTION
This ensures that the headings are tight against the content they refer to. Short headings currently produce a large gap between the heading text and the content inside `bounds`

before:

<img width="405" alt="screen shot 2015-08-07 at 9 46 29 am" src="https://cloud.githubusercontent.com/assets/8643567/9124243/75e65a82-3ce9-11e5-8e96-f724c11bec84.png">

after:

<img width="456" alt="screen shot 2015-08-07 at 9 46 15 am" src="https://cloud.githubusercontent.com/assets/8643567/9124245/7e871bea-3ce9-11e5-88db-8f9e8919af21.png">
