### PR TITLE
Add text--noHyphens class

### DIFF
--- a/sass/modifiers/_text.scss
+++ b/sass/modifiers/_text.scss
@@ -60,6 +60,24 @@ Class                  | Description
 
 /*doc
 ---
+title: No Hyphens
+name: textNoHyphens
+parent: textMod
+---
+Don't allow hyphens on line breaks
+
+Class              | Description
+-------------------| ----------------------------
+`.text--noHyphens` | Don't allow hyphens on line breaks
+*/
+.text--noHyphens {
+	-webkit-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+}
+
+/*doc
+---
 title: Nice Hyphenation
 name: wrapNiceUtil
 parent: textMod


### PR DESCRIPTION
When we don't want to allow certain elements to break their text with hyphens. To be used sparingly.