### PR TITLE
`.view--splitList` should always be `height: 100vh`

### DIFF
--- a/sass/core/view/_view.scss
+++ b/sass/core/view/_view.scss
@@ -96,7 +96,6 @@ the "detail" responsibility.
 		position: fixed;
 		top: 0;
 		left: 0;
-		height: 100vh;
 		width: $view-minWidth;
 		border-right: 1px solid $C_border;
 		display: block;

--- a/sass/core/view/_view.scss
+++ b/sass/core/view/_view.scss
@@ -81,6 +81,7 @@ the "detail" responsibility.
 .view--splitList {
 	overflow-y: scroll;
 	overflow-x: hidden;
+	height: 100vh;
 	z-index: map-get($zindex-map, splitList-view);
 }
 


### PR DESCRIPTION
this is useful for making sure that the list-specific scroll waypoints will fire, but I think in general it's correct, since the list-side of a split view should always perfectly fit the height of the viewport - it's the detail-side of the split that can expand past the bottom of the viewport.