### PR TITLE
Added a 40em max-width to all .runningText paragraphs

### DIFF
--- a/sass/core/type/_body-text.scss
+++ b/sass/core/type/_body-text.scss
@@ -247,6 +247,7 @@ event descriptions).
 .runningText p {
 	@extend %wrapNice;
 	margin-bottom: $space;
+	max-width: 40em;
 	&:last-child {
 		margin-bottom: 0;
 	}


### PR DESCRIPTION
The measure on .runningText didn't make for a comfortable reading experience. Changed the `max-width` of `.runningText > p` to 40em.
We could consider making 40em a variable, but I'm not sure how reusable it is.