### PR TITLE
replace element selectors with explicit class selectors for gridList …

### DIFF
--- a/sass/core/layout/_gridList.scss
+++ b/sass/core/layout/_gridList.scss
@@ -24,28 +24,21 @@ For a layout with a fixed number of columns, use `row`.
 */
 $glColumns: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10;
 
-%_gridList--item {
-	font-size: 1rem;
-	display: inline-block;
-	margin: 0;
-	padding: 0 $space $space 0;
-	vertical-align: top;
-	width: 50%;
-	box-sizing: border-box;
-}
 
 .gridList {
 	margin: 0 #{-$space} 0 0;
 	padding: 0;
 	list-style: none;
 	font-size: 0;
-	> li {
-		@extend %_gridList--item;
-	}
 }
 
 .gridList-item {
-	@extend %_gridList--item;
+	display: inline-block;
+	margin: 0;
+	padding: 0 $space $space 0;
+	vertical-align: top;
+	width: 50%;
+	box-sizing: border-box;
 }
 
 /*doc
@@ -72,14 +65,14 @@ Class                         | Description
 .gridList--photoGrid {
 	margin: 0 #{-($space + $space-half)} 0 #{-$space};
 	padding: 0;
-	> li {
+	> .gridList-item {
 		padding: 0 $space-quarter $space-quarter 0;
 	}
 }
 
 // small/default
 @each $col in $glColumns {
-	.gridList--has#{$col} > li {
+	.gridList--has#{$col} > .gridList-item {
 		width: percentage(1 / $col);
 	}
 }
@@ -87,7 +80,7 @@ Class                         | Description
 // larger breakpoints
 @each $col in $glColumns {
 	@include _bpModifier(gridList, has#{$col}) {
-		> li {
+		> .gridList-item {
 			width: percentage(1 / $col);
 		}
 	}


### PR DESCRIPTION
replace element selectors with explicit class selectors for direct children of `gridList`

fixes #222 