### PR TITLE
Add `border--left` to make a vertical divider

### DIFF
--- a/sass/modifiers/_border.scss
+++ b/sass/modifiers/_border.scss
@@ -9,12 +9,17 @@ Sets border properties on element
 Class                   | Description
 ----------------------- | --------------------------------
 `.border--top`          | sets a standard top border on the element
+`.border--left`         | sets a standard left border on the element
 `.border--none`         | removes all borders from element
 `.bordered`             | sets a standard top border AND top padding
 */
 
 @include _modifier(border, top) {
 	@include standardBorder();
+}
+
+@include _modifier(border, left) {
+	@include standardBorder('left');
 }
 
 @include _modifier(border, none) {


### PR DESCRIPTION
Sometimes you need a vertical divider. Because row elements use margin-right and padding-left, `border--left` is the best way to get a border that evenly divides items in a row.

<img width="847" alt="screen shot 2016-02-23 at 10 32 07 am" src="https://cloud.githubusercontent.com/assets/8643567/13234299/d48461b2-da1c-11e5-8359-3a5aa7281216.png">
