### PR TITLE
Add `input:not([type])` to list of input types

### DIFF
--- a/sass/_globals.scss
+++ b/sass/_globals.scss
@@ -313,6 +313,7 @@ $inputs-list: 'input[type="email"]',
 				  'input[type="tel"]',
 				  'input[type="text"]',
 				  'input[type="url"]',
+			  	  'input:not([type])',
 
 				  // Webkit & Gecko may change the display of these in the future
 				  'input[type="color"]',


### PR DESCRIPTION
This will allow elements without a type specified to have default sassquatch2 text="input" styling