### PR TITLE
Gentler text-protection scrim

### DIFF
--- a/sass/ui-components/_card.scss
+++ b/sass/ui-components/_card.scss
@@ -34,28 +34,10 @@ Card-like boxes.
 
 			<!-- Group card with long name -->
 			<li class="gridList-item">
-				<div class="card card--group inverted" style="background-image: url(http://photos4.meetupstatic.com/photos/event/7/6/f/8/600_434010456.jpeg);">
+				<div class="card card--group inverted" style="background-image: url(http://photos3.meetupstatic.com/photo_api/event/rx308x180/cpt/cr308x180/ql90/sgb54c13bc46/226666972.jpeg);">
 					<div class="card--group-content column">
 						<h4 class="column-item text--headline">Béchamel Hell: French Cuisine for Survivalists Meetup</h4>
 						<p class="column-item column-item--shrink">457 [chapter.who]</p>
-					</div>
-				</div>
-			</li>
-
-			<!-- Group card with quick-join -->
-			<li class="gridList-item">
-				<div class="card card--group inverted" style="background-image: url(http://photos4.meetupstatic.com/photos/event/7/6/f/8/600_434010456.jpeg);">
-					<div class="card--group-content column">
-						<h4 class="column-item text--headline">Some Meetup Group Name</h4>
-						<div class="column-item column-item--shrink row">
-							<p class="row-item valign--middle">457 [chapter.who]</p>
-							<div class="row-item row-item--shrink quickJoin valign--bottom">
-								<span class="toggleButton toggleButton--join">
-							    <input class="toggleButton-input" type="checkbox" name="join-mug" id="join-mug" value="ToggleBtn">
-							    <label class="toggleButton-label" for="join-mug">+</label>
-								</span>
-							</div>
-						</div>
 					</div>
 				</div>
 			</li>
@@ -242,7 +224,7 @@ $_eventStripes: (
 	border-radius: 0;
 	padding: $space;
 	height: $block-4;
-  text-shadow: 1px 1px 1px $C_borderDark;
+  text-shadow: 1px 1px 0 $C_textHint;
 	filter: grayscale(20%) contrast(110%);
 	-webkit-filter: grayscale(20%) contrast(110%);
   .text--headline {

--- a/sass/ui-components/_card.scss
+++ b/sass/ui-components/_card.scss
@@ -238,8 +238,7 @@ $_eventStripes: (
 }
 
 .card--group {
-	@include valignChildren(top);
-	@include textProtectionScrim(all);
+	@include textProtectionScrim(top);
 	border-radius: 0;
 	padding: $space;
 	height: $block-4;

--- a/sass/ui-components/_card.scss
+++ b/sass/ui-components/_card.scss
@@ -25,9 +25,9 @@ Card-like boxes.
 			<!-- Group card -->
 			<li class="gridList-item">
 				<div class="card card--group inverted" style="background-image: url(http://photos4.meetupstatic.com/photos/event/7/6/f/8/600_434010456.jpeg);">
-					<div class="card--group-content">
-						<h4 class="text--headline">Some Meetup Group Name</h4>
-						<p>457 [chapter.who]</p>
+					<div class="card--group-content column">
+						<h4 class="column-item text--headline">Some Meetup Group Name</h4>
+						<p class="column-item column-item--shrink">457 [chapter.who]</p>
 					</div>
 				</div>
 			</li>
@@ -35,9 +35,27 @@ Card-like boxes.
 			<!-- Group card with long name -->
 			<li class="gridList-item">
 				<div class="card card--group inverted" style="background-image: url(http://photos4.meetupstatic.com/photos/event/7/6/f/8/600_434010456.jpeg);">
-					<div class="card--group-content">
-						<h4 class="text--headline">Béchamel Hell: French Cuisine for Survivalists Meetup</h4>
-						<p>457 [chapter.who]</p>
+					<div class="card--group-content column">
+						<h4 class="column-item text--headline">Béchamel Hell: French Cuisine for Survivalists Meetup</h4>
+						<p class="column-item column-item--shrink">457 [chapter.who]</p>
+					</div>
+				</div>
+			</li>
+
+			<!-- Group card with quick-join -->
+			<li class="gridList-item">
+				<div class="card card--group inverted" style="background-image: url(http://photos4.meetupstatic.com/photos/event/7/6/f/8/600_434010456.jpeg);">
+					<div class="card--group-content column">
+						<h4 class="column-item text--headline">Some Meetup Group Name</h4>
+						<div class="column-item column-item--shrink row">
+							<p class="row-item valign--middle">457 [chapter.who]</p>
+							<div class="row-item row-item--shrink quickJoin valign--bottom">
+								<span class="toggleButton toggleButton--join">
+							    <input class="toggleButton-input" type="checkbox" name="join-mug" id="join-mug" value="ToggleBtn">
+							    <label class="toggleButton-label" for="join-mug">+</label>
+								</span>
+							</div>
+						</div>
 					</div>
 				</div>
 			</li>
@@ -221,11 +239,13 @@ $_eventStripes: (
 
 .card--group {
 	@include valignChildren(top);
-	@include textProtectionScrim(top);
+	@include textProtectionScrim(all);
 	border-radius: 0;
 	padding: $space;
 	height: $block-4;
   text-shadow: 1px 1px 1px $C_borderDark;
+	filter: grayscale(20%) contrast(110%);
+	-webkit-filter: grayscale(20%) contrast(110%);
   .text--headline {
   	font-weight: $W_bold;
   }

--- a/sass/ui-components/_toggle-pill.scss
+++ b/sass/ui-components/_toggle-pill.scss
@@ -145,3 +145,45 @@ Checkbox form elements styled as toggle buttons.
 .toggleButton-icon {
 	margin-left: $space-quarter;
 }
+
+.quickJoin {
+	box-sizing: content-box;
+	height: $media-xs;
+	width: $media-xs;
+}
+
+.toggleButton--join {
+	position: absolute;
+	bottom: 0;
+	right: 0;
+	margin: 0;
+	text-shadow: none;
+
+	.toggleButton-label {
+		border-radius: 999px;
+		border: 1px solid $C_textPrimaryInverted;
+		height: $media-xs;
+		width: $media-xs;
+
+		&:hover,
+		&:active,
+		&:focus {
+			background: transparent;
+		}
+	}
+
+	.toggleButton-input {
+
+		&:checked + .toggleButton-label {
+			background: $C_textPrimaryInverted;
+			color: $C_textPrimary;
+			height: auto;
+			width: auto;
+		}
+
+	}
+}
+
+.quickJoin {
+	position: relative;
+}

--- a/sass/util/_type.scss
+++ b/sass/util/_type.scss
@@ -58,8 +58,9 @@ Adds a pseudo-element gradient
 @mixin textProtectionScrim($placement: 'top'); // 'bottom' will place gradent on bottom of el
 ```
 */
-$C_scrimGradient: #0F141F; // move to swatches?
+$C_scrimGradient: $C_black; // move to swatches?
 @mixin textProtectionScrim($placement: 'bottom') {
+
 	&:before {
 		content: '';
 		display: block;
@@ -68,12 +69,13 @@ $C_scrimGradient: #0F141F; // move to swatches?
 		width: 100%;
 		z-index: 0;
 		left: 0;
+    mix-blend-mode: hard-light;
 
 		@if $placement == 'bottom' {
-			@include linear-gradient(180deg, transparentize($C_scrimGradient, 1) 0%, transparentize($C_scrimGradient, .9) 25%, transparentize($C_scrimGradient, .1) 100%);
+			@include linear-gradient(180deg, transparentize($C_scrimGradient, .85) 25%, transparentize($C_scrimGradient, .4) 100%);
 			bottom: 0;
 		} @else {
-			@include linear-gradient(0deg, transparentize($C_scrimGradient, 1) 0%, transparentize($C_scrimGradient, .9) 25%, transparentize($C_scrimGradient, .3) 100%);
+			@include linear-gradient(0deg, transparentize($C_scrimGradient, .85) 25%, transparentize($C_scrimGradient, .4) 100%);
 			top: 0;
 		}
 	}

--- a/sass/util/_type.scss
+++ b/sass/util/_type.scss
@@ -58,7 +58,7 @@ Adds a pseudo-element gradient
 @mixin textProtectionScrim($placement: 'top'); // 'bottom' will place gradent on bottom of el
 ```
 */
-$C_scrimGradient: $C_black; // move to swatches?
+$C_scrimGradient: $C_black;
 @mixin textProtectionScrim($placement: 'bottom') {
 
 	&:before {
@@ -72,10 +72,10 @@ $C_scrimGradient: $C_black; // move to swatches?
     mix-blend-mode: hard-light;
 
 		@if $placement == 'bottom' {
-			@include linear-gradient(180deg, transparentize($C_scrimGradient, .85) 25%, transparentize($C_scrimGradient, .4) 100%);
+			@include linear-gradient(180deg, transparentize($C_scrimGradient, .85) 25%, transparentize($C_scrimGradient, .6) 100%);
 			bottom: 0;
 		} @else {
-			@include linear-gradient(0deg, transparentize($C_scrimGradient, .85) 25%, transparentize($C_scrimGradient, .4) 100%);
+			@include linear-gradient(0deg, transparentize($C_scrimGradient, .85) 25%, transparentize($C_scrimGradient, .6) 100%);
 			top: 0;
 		}
 	}


### PR DESCRIPTION
Using fancy new things like blend-modes on the gradient and CSS filters to help readability while making the scrim subtler.

Scrim falls back to just use `rgba` gradient for browsers that don't support this.