### PR TITLE
Immediate anchor children of gridList-item should be block els

### DIFF
--- a/sass/core/layout/_gridList.scss
+++ b/sass/core/layout/_gridList.scss
@@ -40,6 +40,9 @@ $glColumns: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10;
 	vertical-align: top;
 	width: 50%;
 	box-sizing: border-box;
+	> a {
+		display: block;
+	}
 }
 
 /*doc


### PR DESCRIPTION
Improves the size of the click target and helps ensure layout structure