### PR TITLE
fixes #297

### DIFF
--- a/sass/core/type/_body-text.scss
+++ b/sass/core/type/_body-text.scss
@@ -37,7 +37,7 @@ elements to inveted colors.
 */
 %inverted,
 .inverted {
-	color: $C_textPrimaryInverted;
+	@include color-all($C_textPrimaryInverted);
 }
 
 


### PR DESCRIPTION
use `color-all` mixin to set the `fill` property in addition to the `color` property in inverted context