### PR TITLE
Remove peer deps except for meetup-swatches

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"type": "MIT",
 		"url": "https://github.com/meetup/sassquatch2/blob/master/LICENSE"
 	},
-	"peerDependencies": {
+	"dependencies": {
 		"bourbon": "4.2.3",
 		"julep": "1.4.5",
 		"meetup-swatches": "3.1.1"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
 		"type": "MIT",
 		"url": "https://github.com/meetup/sassquatch2/blob/master/LICENSE"
 	},
+	"peerDependencies": {
+		"meetup-swatches": "^3.1.1"
+	},
 	"dependencies": {
 		"bourbon": "4.2.3",
 		"julep": "1.4.5",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"grunt-contrib-clean": "0.6.0",
 		"grunt-preprocess": "4.1.0",
 		"grunt-exec": "1.0.0",
+		"node-sass": "3.11.1",
 		"webpack": "^1.13.1",
 		"css-loader": "0.23.1",
 		"sass-loader": "4.0.0",


### PR DESCRIPTION
The bourbon and julep libs are dependencies for this repo, since it directly imports them and expects them to work in a certain way.

If client applications import those libs separately for client-specific code, it shouldn't be influenced by what is imported by sassquatch2.

The exception to this is meetup-swatches, which presumably needs to have the same colors as those provided by sassquatch2 regardless of who imports it. It should still be in the dependencies list, though, since it is a package dependency